### PR TITLE
#694 - NftApi

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "bitcoin-php/bitcoin-ecdsa": "1.3.4",
         "symfony/validator": "^4.2",
         "symfony/process": "^4.2",
-        "codacy/coverage": "^1.4"
+        "codacy/coverage": "^1.4",
+        "symfony/serializer": "^4.3",
+        "symfony/property-info": "^4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06224f89600ee077f5f0a24033cac50a",
+    "content-hash": "1a40d5b6cebc9718a8abceb5af069813",
     "packages": [
         {
             "name": "bitcoin-php/bitcoin-ecdsa",
@@ -915,6 +915,162 @@
                 "reflection"
             ],
             "time": "2019-01-16T09:39:14+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "9a3d5ba14694017a29cada773ce770845224d9e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/9a3d5ba14694017a29cada773ce770845224d9e4",
+                "reference": "9a3d5ba14694017a29cada773ce770845224d9e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/inflector": "~3.4|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.3.0",
+                "symfony/dependency-injection": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/serializer": "~3.4|~4.0"
+            },
+            "suggest": {
+                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
+                "psr/cache-implementation": "To cache results",
+                "symfony/doctrine-bridge": "To use Doctrine metadata",
+                "symfony/serializer": "To use Serializer metadata"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Property Info Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "time": "2019-05-20T16:16:12+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "7a05742647711bc371e9fa1d71206561b88d093a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/7a05742647711bc371e9fa1d71206561b88d093a",
+                "reference": "7a05742647711bc371e9fa1d71206561b88d093a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "phpdocumentor/type-resolver": "<0.2.1",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/property-access": "<3.4",
+                "symfony/property-info": "<3.4",
+                "symfony/yaml": "<3.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/http-foundation": "~3.4|~4.0",
+                "symfony/property-access": "~3.4|~4.0",
+                "symfony/property-info": "^3.4.13|~4.0",
+                "symfony/validator": "~3.4|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/http-foundation": "To use the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Serializer Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-06-05T13:25:51+00:00"
         },
         {
             "name": "symfony/validator",

--- a/src/DCoreApi.php
+++ b/src/DCoreApi.php
@@ -28,6 +28,7 @@ use DCorePHP\Sdk\SeederApi;
 use DCorePHP\Sdk\SubscriptionApi;
 use DCorePHP\Sdk\TransactionApi;
 use DCorePHP\Sdk\ValidationApi;
+use InvalidArgumentException;
 use WebSocket\BadOpcodeException;
 
 class DCoreApi extends DCoreSdk
@@ -488,5 +489,12 @@ class DCoreApi extends DCoreSdk
             ->setChainId($chainId);
 
         return $transaction;
+    }
+
+    public static function require(bool $value, string $message = 'An Exception occurred'): void
+    {
+        if (!$value) {
+            throw new InvalidArgumentException($message);
+        }
     }
 }

--- a/src/DCoreApi.php
+++ b/src/DCoreApi.php
@@ -6,6 +6,7 @@ use DCorePHP\Exception\InvalidApiCallException;
 use DCorePHP\Model\BaseOperation;
 use DCorePHP\Model\BlockData;
 use DCorePHP\Model\DynamicGlobalProps;
+use DCorePHP\Model\NftData;
 use DCorePHP\Model\Transaction;
 use DCorePHP\Net\JsonRpc;
 use DCorePHP\Net\Model\Request\BaseRequest;
@@ -39,6 +40,8 @@ class DCoreApi extends DCoreSdk
      */
     public const TRANSACTION_EXPIRATION = 30;
     public const REQ_LIMIT_MAX = 100;
+
+    private $registeredNfts = [];
 
     /** @var array */
     protected $permissions = [];
@@ -489,5 +492,13 @@ class DCoreApi extends DCoreSdk
             ->setChainId($chainId);
 
         return $transaction;
+    }
+
+    public function registerNfts(array $idToClass): void {
+        $this->registeredNfts = array_merge($this->registeredNfts, $idToClass);
+    }
+
+    public function isRegistered(string $nftId) {
+        return $this->registeredNfts[$nftId] ?? null;
     }
 }

--- a/src/DCoreApi.php
+++ b/src/DCoreApi.php
@@ -21,6 +21,7 @@ use DCorePHP\Sdk\GeneralApi;
 use DCorePHP\Sdk\HistoryApi;
 use DCorePHP\Sdk\MessagingApi;
 use DCorePHP\Sdk\MiningApi;
+use DCorePHP\Sdk\NftApi;
 use DCorePHP\Sdk\ProposalApi;
 use DCorePHP\Sdk\PurchaseApi;
 use DCorePHP\Sdk\SeederApi;
@@ -36,6 +37,7 @@ class DCoreApi extends DCoreSdk
      * after the expiry the transaction is removed from recent pool and will be dismissed if not included in DCore block
      */
     public const TRANSACTION_EXPIRATION = 30;
+    public const REQ_LIMIT_MAX = 100;
 
     /** @var array */
     protected $permissions = [];
@@ -77,6 +79,8 @@ class DCoreApi extends DCoreSdk
     private $broadcastApi;
     /** @var BalanceApi */
     private $balanceApi;
+    /** @var NftApi */
+    private $nftApi;
 
     public function __construct(string $dcoreApiUrl, string $dcoreWebsocketUrl, bool $debug = false)
     {
@@ -98,6 +102,7 @@ class DCoreApi extends DCoreSdk
         $this->blockApi = new BlockApi($this);
         $this->broadcastApi = new BroadcastApi($this);
         $this->balanceApi = new BalanceApi($this);
+        $this->nftApi = new NftApi($this);
     }
 
     /**
@@ -198,7 +203,7 @@ class DCoreApi extends DCoreSdk
     /**
      * @param SeederApi $seederApi
      */
-    public function setSeedingGroup(SeederApi $seederApi): void
+    public function setSeedingApi(SeederApi $seederApi): void
     {
         $this->seederApi = $seederApi;
     }
@@ -431,6 +436,25 @@ class DCoreApi extends DCoreSdk
     public function setBalanceApi(BalanceApi $balanceApi): DCoreApi
     {
         $this->balanceApi = $balanceApi;
+
+        return $this;
+    }
+
+    /**
+     * @return NftApi
+     */
+    public function getNftApi(): NftApi
+    {
+        return $this->nftApi;
+    }
+
+    /**
+     * @param NftApi $nftApi
+     * @return DCoreApi
+     */
+    public function setNftApi(NftApi $nftApi): DCoreApi
+    {
+        $this->nftApi = $nftApi;
 
         return $this;
     }

--- a/src/DCoreApi.php
+++ b/src/DCoreApi.php
@@ -490,11 +490,4 @@ class DCoreApi extends DCoreSdk
 
         return $transaction;
     }
-
-    public static function require(bool $value, string $message = 'An Exception occurred'): void
-    {
-        if (!$value) {
-            throw new InvalidArgumentException($message);
-        }
-    }
 }

--- a/src/DCoreConstants.php
+++ b/src/DCoreConstants.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DCorePHP;
+
+class DCoreConstants
+{
+    public const UIA_DESCRIPTION_MAX_CHARS = 1000;
+    public const NFT_NAME_MAX_CHARS = 32;
+}

--- a/src/Model/Nft.php
+++ b/src/Model/Nft.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace DCorePHP\Model;
+
+use DCorePHP\Exception\ValidationException;
+
+class Nft
+{
+    /** @var ChainObject */
+    private $id;
+    /** @var string */
+    private $symbol;
+    /** @var NftOptions */
+    private $options;
+    /** @var NftDataType[] */
+    private $definitions;
+    /** @var bool */
+    private $fixedMaxSupply;
+    /** @var bool */
+    private $transferable;
+    /** @var string */
+    private $currentSupply;
+
+    /**
+     * Nft constructor.
+     */
+    public function __construct()
+    {
+        $this->options = new NftOptions();
+    }
+
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject|string $id
+     * @return Nft
+     * @throws ValidationException
+     */
+    public function setId($id): Nft
+    {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @param string $symbol
+     * @return Nft
+     */
+    public function setSymbol(string $symbol): Nft
+    {
+        $this->symbol = $symbol;
+
+        return $this;
+    }
+
+    /**
+     * @return NftOptions
+     */
+    public function getOptions(): NftOptions
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param NftOptions $options
+     * @return Nft
+     */
+    public function setOptions(NftOptions $options): Nft
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return NftDataType[]
+     */
+    public function getDefinitions(): array
+    {
+        return $this->definitions;
+    }
+
+    /**
+     * @param NftDataType[] $definitions
+     * @return Nft
+     */
+    public function setDefinitions(array $definitions): Nft
+    {
+        $this->definitions = $definitions;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFixedMaxSupply(): bool
+    {
+        return $this->fixedMaxSupply;
+    }
+
+    /**
+     * @param bool $fixedMaxSupply
+     * @return Nft
+     */
+    public function setFixedMaxSupply(bool $fixedMaxSupply): Nft
+    {
+        $this->fixedMaxSupply = $fixedMaxSupply;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTransferable(): bool
+    {
+        return $this->transferable;
+    }
+
+    /**
+     * @param bool $transferable
+     * @return Nft
+     */
+    public function setTransferable(bool $transferable): Nft
+    {
+        $this->transferable = $transferable;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentSupply(): string
+    {
+        return $this->currentSupply;
+    }
+
+    /**
+     * @param string $currentSupply
+     * @return Nft
+     */
+    public function setCurrentSupply(string $currentSupply): Nft
+    {
+        $this->currentSupply = $currentSupply;
+
+        return $this;
+    }
+}

--- a/src/Model/NftData.php
+++ b/src/Model/NftData.php
@@ -2,6 +2,9 @@
 
 namespace DCorePHP\Model;
 
+use DCorePHP\Exception\ValidationException;
+use ReflectionException;
+
 class NftData
 {
     /** @var ChainObject */
@@ -12,4 +15,111 @@ class NftData
     private $owner;
     /** @var mixed */
     private $data;
+
+    /**
+     * @param NftData $nft
+     * @param $class
+     *
+     * @return NftData
+     * @throws ValidationException
+     * @throws ReflectionException
+     */
+    public static function init(NftData $nft, $class): NftData
+    {
+        $instance = new self();
+        $data = NftModel::make($nft->getData(), $class);
+        return $instance->setId($nft->getId())->setNftId($nft->getNftId())->setOwner($nft->getOwner())->setData($data);
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject|string $id
+     *
+     * @return NftData
+     * @throws ValidationException
+     */
+    public function setId($id): NftData
+    {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getNftId(): ChainObject
+    {
+        return $this->nftId;
+    }
+
+    /**
+     * @param ChainObject|string $nftId
+     *
+     * @return NftData
+     * @throws ValidationException
+     */
+    public function setNftId($nftId): NftData
+    {
+        if (is_string($nftId)) {
+            $nftId = new ChainObject($nftId);
+        }
+        $this->nftId = $nftId;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getOwner(): ChainObject
+    {
+        return $this->owner;
+    }
+
+    /**
+     * @param ChainObject|string $owner
+     *
+     * @return NftData
+     * @throws ValidationException
+     */
+    public function setOwner($owner): NftData
+    {
+        if (is_string($owner)) {
+            $owner = new ChainObject($owner);
+        }
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return NftData
+     */
+    public function setData($data): NftData
+    {
+        $this->data = $data;
+
+        return $this;
+    }
 }

--- a/src/Model/NftData.php
+++ b/src/Model/NftData.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DCorePHP\Model;
+
+class NftData
+{
+    /** @var ChainObject */
+    private $id;
+    /** @var ChainObject */
+    private $nftId;
+    /** @var ChainObject */
+    private $owner;
+    /** @var mixed */
+    private $data;
+}

--- a/src/Model/NftDataType.php
+++ b/src/Model/NftDataType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DCorePHP\Model;
+
+use DCorePHP\DCoreConstants;
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
+use InvalidArgumentException;
+
+class NftDataType
+{
+    private const modifiableOrdinal = [self::NOBODY => 0, self::ISSUER => 1, self::OWNER => 2, self::BOTH => 3];
+    public const NOBODY = 'nobody';
+    public const ISSUER = 'issuer';
+    public const OWNER = 'owner';
+    public const BOTH = 'both';
+
+    private const typeOrdinal = [self::TYPE_STRING => 0, self::TYPE_INTEGER => 1, self::TYPE_BOOLEAN => 2];
+    public const TYPE_STRING = 'string';
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_BOOLEAN = 'boolean';
+
+    /** @var mixed */
+    private $type;
+    /** @var bool */
+    private $unique = false;
+    /** @var string */
+    private $modifiable = self::NOBODY;
+    /** @var string */
+    private $name;
+
+    public static function withValues($type, string $name, bool $unique = false, string $modifiable = self::NOBODY): NftDataType
+    {
+        $dataType = new self();
+        return $dataType
+            ->setType($type)
+            ->setUnique($unique)
+            ->setModifiable($modifiable)
+            ->setName($name);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param mixed $type
+     * @return NftDataType
+     */
+    public function setType($type): NftDataType
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUnique(): bool
+    {
+        return $this->unique;
+    }
+
+    /**
+     * @param bool $unique
+     * @return NftDataType
+     */
+    public function setUnique(bool $unique): NftDataType
+    {
+        $this->unique = $unique;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModifiable(): string
+    {
+        return $this->modifiable;
+    }
+
+    /**
+     * @param string $modifiable
+     * @return NftDataType
+     */
+    public function setModifiable(string $modifiable): NftDataType
+    {
+        $this->modifiable = $modifiable;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return NftDataType
+     */
+    public function setName(string $name): NftDataType
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        if ($this->modifiable === self::NOBODY || $this->name === null) {
+            throw new InvalidArgumentException('modifiable data type must have name');
+        }
+
+        if ($this->name === null || strlen($this->name) > DCoreConstants::NFT_NAME_MAX_CHARS) {
+            throw new InvalidArgumentException('name cannot be longer then ' . DCoreConstants::NFT_NAME_MAX_CHARS . 'chars');
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->getType(),
+            'unique' => $this->isUnique(),
+            'modifiable' => $this->getModifiable(),
+            'name' => $this->getName()
+        ];
+    }
+
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->isUnique() ? '01' : '00',
+            Math::getInt64('' . self::modifiableOrdinal[$this->getModifiable()]),
+            Math::getInt64('' . self::typeOrdinal[$this->getType()]),
+            $this->getName() ?
+                '01' .
+                VarInt::encodeDecToHex(sizeof(Math::stringToByteArray($this->getName()))) .
+                Math::byteArrayToHex(Math::stringToByteArray($this->getName()))
+                : '00'
+        ]);
+    }
+}

--- a/src/Model/NftDataType.php
+++ b/src/Model/NftDataType.php
@@ -29,7 +29,7 @@ class NftDataType
     /** @var string */
     private $name;
 
-    public static function withValues($type, string $name, bool $unique = false, string $modifiable = self::NOBODY): NftDataType
+    public static function withValues($type, bool $unique = false, string $modifiable = self::NOBODY, string $name = null): NftDataType
     {
         $dataType = new self();
         return $dataType
@@ -99,7 +99,7 @@ class NftDataType
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -108,7 +108,7 @@ class NftDataType
      * @param string $name
      * @return NftDataType
      */
-    public function setName(string $name): NftDataType
+    public function setName(?string $name): NftDataType
     {
         $this->name = $name;
 
@@ -117,11 +117,11 @@ class NftDataType
 
     public function validate(): void
     {
-        if ($this->modifiable === self::NOBODY || $this->name === null) {
+        if ($this->modifiable !== self::NOBODY && $this->name === null) {
             throw new InvalidArgumentException('modifiable data type must have name');
         }
 
-        if ($this->name === null || strlen($this->name) > DCoreConstants::NFT_NAME_MAX_CHARS) {
+        if ($this->name !== null && strlen($this->name) > DCoreConstants::NFT_NAME_MAX_CHARS) {
             throw new InvalidArgumentException('name cannot be longer then ' . DCoreConstants::NFT_NAME_MAX_CHARS . 'chars');
         }
     }

--- a/src/Model/NftDataType.php
+++ b/src/Model/NftDataType.php
@@ -22,6 +22,8 @@ class NftDataType
 
     /** @var mixed */
     private $type;
+    /** @var mixed */
+    private $value;
     /** @var bool */
     private $unique = false;
     /** @var string */
@@ -29,11 +31,12 @@ class NftDataType
     /** @var string */
     private $name;
 
-    public static function withValues($type, bool $unique = false, string $modifiable = self::NOBODY, string $name = null): NftDataType
+    public static function withValues($type, $value = null, bool $unique = false, string $modifiable = self::NOBODY, string $name = null): NftDataType
     {
         $dataType = new self();
         return $dataType
             ->setType($type)
+            ->setValue($value)
             ->setUnique($unique)
             ->setModifiable($modifiable)
             ->setName($name);
@@ -54,6 +57,26 @@ class NftDataType
     public function setType($type): NftDataType
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return NftDataType
+     */
+    public function setValue($value): NftDataType
+    {
+        $this->value = $value;
 
         return $this;
     }

--- a/src/Model/NftModel.php
+++ b/src/Model/NftModel.php
@@ -2,9 +2,51 @@
 
 namespace DCorePHP\Model;
 
-use ReflectionClass;
-use ReflectionException;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
 
 class NftModel
 {
+
+    private $values = [];
+    /** @var Serializer */
+    private $serializer;
+
+    /**
+     * NftModel constructor.
+     */
+    public function __construct()
+    {
+        $this->serializer = new Serializer(
+            [new ObjectNormalizer()],
+            [new JsonEncoder()]
+        );
+    }
+
+    /**
+     * @return NftDataType[]
+     * @throws ExceptionInterface
+     */
+    public function createDefinitions(): array {
+        $this->values();
+        $dataTypes = [];
+        foreach ($this->values as $value) {
+            $dataTypes[] = $this->serializer->deserialize($value, NftDataType::class, 'json');
+        }
+        return $dataTypes;
+    }
+    /**
+     * @throws ExceptionInterface
+     */
+    public function values(): array {
+        if (!empty($this->values)) return $this->values;
+
+        $normalizedArray = $this->serializer->normalize($this);
+        foreach ($normalizedArray as $item) {
+            $this->values[] = $this->serializer->encode($item, 'json');
+        }
+        return $this->values;
+    }
 }

--- a/src/Model/NftModel.php
+++ b/src/Model/NftModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DCorePHP\Model;
+
+use ReflectionClass;
+use ReflectionException;
+
+class NftModel
+{
+}

--- a/src/Model/NftModel.php
+++ b/src/Model/NftModel.php
@@ -2,6 +2,8 @@
 
 namespace DCorePHP\Model;
 
+use ReflectionClass;
+use ReflectionException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -61,5 +63,17 @@ class NftModel
             $values[] = new Variant($definition->getType(), $definition->getValue());
         }
         return $values;
+    }
+
+    /**
+     * @param $data
+     * @param $class
+     *
+     * @return object
+     * @throws ReflectionException
+     */
+    public static function make($data, $class) {
+        $reflection = new ReflectionClass($class);
+        return $reflection->newInstanceArgs($data);
     }
 }

--- a/src/Model/NftModel.php
+++ b/src/Model/NftModel.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Serializer;
 class NftModel
 {
 
-    private $values = [];
+    private $json = [];
     /** @var Serializer */
     private $serializer;
 
@@ -30,9 +30,9 @@ class NftModel
      * @throws ExceptionInterface
      */
     public function createDefinitions(): array {
-        $this->values();
+        $this->json();
         $dataTypes = [];
-        foreach ($this->values as $value) {
+        foreach ($this->json as $value) {
             $dataTypes[] = $this->serializer->deserialize($value, NftDataType::class, 'json');
         }
         return $dataTypes;
@@ -40,13 +40,26 @@ class NftModel
     /**
      * @throws ExceptionInterface
      */
-    public function values(): array {
-        if (!empty($this->values)) return $this->values;
+    public function json(): array {
+        if (!empty($this->json)) return $this->json;
 
         $normalizedArray = $this->serializer->normalize($this);
         foreach ($normalizedArray as $item) {
-            $this->values[] = $this->serializer->encode($item, 'json');
+            $this->json[] = $this->serializer->encode($item, 'json');
         }
-        return $this->values;
+        return $this->json;
+    }
+
+    /**
+     * @return array
+     * @throws ExceptionInterface
+     */
+    public function values(): array {
+        $definitions = $this->createDefinitions();
+        $values = [];
+        foreach ($definitions as $definition) {
+            $values[] = new Variant($definition->getType(), $definition->getValue());
+        }
+        return $values;
     }
 }

--- a/src/Model/NftModel.php
+++ b/src/Model/NftModel.php
@@ -76,4 +76,18 @@ class NftModel
         $reflection = new ReflectionClass($class);
         return $reflection->newInstanceArgs($data);
     }
+
+    /**
+     * @return array
+     * @throws ExceptionInterface
+     */
+    public function createUpdate(): array {
+        $definitions = $this->createDefinitions();
+        $filtered = array_filter($definitions, static function (NftDataType $definition) { return $definition->getModifiable() !== NftDataType::NOBODY; });
+        $res = [];
+        foreach ($filtered as $item) {
+            $res[] = new Variant($item->getType(), $item->getValue(), $item->getName());
+        }
+        return $res;
+    }
 }

--- a/src/Model/NftOptions.php
+++ b/src/Model/NftOptions.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace DCorePHP\Model;
+
+use DCorePHP\DCoreConstants;
+use DCorePHP\Exception\ValidationException;
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
+use Symfony\Component\Validator\Constraints\LessThanOrEqual;
+use Symfony\Component\Validator\Validation;
+
+class NftOptions
+{
+    /** @var ChainObject */
+    private $issuer;
+    /** @var string */
+    private $maxSupply;
+    /** @var bool */
+    private $fixedMaxSupply;
+    /** @var string */
+    private $description;
+
+    /**
+     * @return ChainObject
+     */
+    public function getIssuer(): ChainObject
+    {
+        return $this->issuer;
+    }
+
+    /**
+     * @param ChainObject|string $issuer
+     * @return NftOptions
+     * @throws ValidationException
+     */
+    public function setIssuer($issuer): NftOptions
+    {
+        if (is_string($issuer)) {
+            $issuer = new ChainObject($issuer);
+        }
+        $this->issuer = $issuer;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMaxSupply(): string
+    {
+        return $this->maxSupply;
+    }
+
+    /**
+     * @param string $maxSupply
+     * @return NftOptions
+     */
+    public function setMaxSupply(string $maxSupply): NftOptions
+    {
+        $this->maxSupply = $maxSupply;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFixedMaxSupply(): bool
+    {
+        return $this->fixedMaxSupply;
+    }
+
+    /**
+     * @param bool $fixedMaxSupply
+     * @return NftOptions
+     */
+    public function setFixedMaxSupply(bool $fixedMaxSupply): NftOptions
+    {
+        $this->fixedMaxSupply = $fixedMaxSupply;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     * @return NftOptions
+     */
+    public function setDescription(string $description): NftOptions
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function validateMaxSupply(): void {
+        [$subject, $constraints] = [gmp_cmp($this->maxSupply, DCoreConstants::UIA_DESCRIPTION_MAX_CHARS), [
+            new LessThanOrEqual([
+                'value' => 0,
+                'message' => 'Max supply max value overflow'])]];
+        if (($violations = Validation::createValidator()->validate($subject, $constraints))->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'issuer' => $this->getIssuer()->getId(),
+            'max_supply' => $this->getMaxSupply(),
+            'fixed_max_supply' => $this->isFixedMaxSupply(),
+            'description' => $this->getDescription()
+        ];
+    }
+
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getIssuer()->toBytes(),
+            Math::getInt32($this->getMaxSupply()),
+            $this->isFixedMaxSupply() ? '01' : '00',
+            VarInt::encodeDecToHex(sizeof(Math::stringToByteArray($this->getDescription()))),
+            Math::byteArrayToHex(Math::stringToByteArray($this->getDescription())),
+        ]);
+    }
+}

--- a/src/Model/NftOptions.php
+++ b/src/Model/NftOptions.php
@@ -2,11 +2,11 @@
 
 namespace DCorePHP\Model;
 
-use DCorePHP\DCoreApi;
 use DCorePHP\DCoreConstants;
 use DCorePHP\Exception\ValidationException;
 use DCorePHP\Utils\Math;
 use DCorePHP\Utils\VarInt;
+use InvalidArgumentException;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Validation;
 
@@ -27,9 +27,17 @@ class NftOptions
         $fixedMaxSupply = $fixedMaxSupply ?? $this->fixedMaxSupply;
         $description = $description ?? $this->description;
 
-        DCoreApi::require($maxSupply >= $this->maxSupply, "Max supply must be at least $this->maxSupply");
-        DCoreApi::require($fixedMaxSupply === $this->fixedMaxSupply || !$this->fixedMaxSupply, 'Max supply must remain fixed');
-        DCoreApi::require($maxSupply === $this->maxSupply || !$this->fixedMaxSupply, 'Can not change max supply (it\'s fixed)');
+        if ($maxSupply < $this->maxSupply) {
+            throw new InvalidArgumentException("Max supply must be at least $this->maxSupply");
+        }
+
+        if ($fixedMaxSupply !== $this->fixedMaxSupply && $this->isFixedMaxSupply()) {
+            throw new InvalidArgumentException('Max supply must remain fixed');
+        }
+
+        if ($maxSupply !== $this->maxSupply && $this->isFixedMaxSupply()) {
+            throw new InvalidArgumentException('Can not change max supply (it\'s fixed)');
+        }
 
         $this->maxSupply = $maxSupply;
         $this->fixedMaxSupply = $fixedMaxSupply;

--- a/src/Model/NftOptions.php
+++ b/src/Model/NftOptions.php
@@ -2,6 +2,7 @@
 
 namespace DCorePHP\Model;
 
+use DCorePHP\DCoreApi;
 use DCorePHP\DCoreConstants;
 use DCorePHP\Exception\ValidationException;
 use DCorePHP\Utils\Math;
@@ -19,6 +20,21 @@ class NftOptions
     private $fixedMaxSupply;
     /** @var string */
     private $description;
+
+    public function update(string $maxSupply = null, bool $fixedMaxSupply = null, string $description = null): void
+    {
+        $maxSupply = $maxSupply ?? $this->maxSupply;
+        $fixedMaxSupply = $fixedMaxSupply ?? $this->fixedMaxSupply;
+        $description = $description ?? $this->description;
+
+        DCoreApi::require($maxSupply >= $this->maxSupply, "Max supply must be at least $this->maxSupply");
+        DCoreApi::require($fixedMaxSupply === $this->fixedMaxSupply || !$this->fixedMaxSupply, 'Max supply must remain fixed');
+        DCoreApi::require($maxSupply === $this->maxSupply || !$this->fixedMaxSupply, 'Can not change max supply (it\'s fixed)');
+
+        $this->maxSupply = $maxSupply;
+        $this->fixedMaxSupply = $fixedMaxSupply;
+        $this->description = $description;
+    }
 
     /**
      * @return ChainObject

--- a/src/Model/Operation/NftCreateOperation.php
+++ b/src/Model/Operation/NftCreateOperation.php
@@ -84,9 +84,9 @@ class NftCreateOperation extends BaseOperation
      */
     public function setDefinitions(array $definitions): NftCreateOperation
     {
-//        foreach ($definitions as $definition) {
-//            $definition->validate();
-//        }
+        foreach ($definitions as $definition) {
+            $definition->validate();
+        }
         $this->definitions = $definitions;
 
         return $this;

--- a/src/Model/Operation/NftCreateOperation.php
+++ b/src/Model/Operation/NftCreateOperation.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace DCorePHP\Model\Operation;
+
+use DCorePHP\DCoreConstants;
+use DCorePHP\Exception\ValidationException;
+use DCorePHP\Model\Asset\Asset;
+use DCorePHP\Model\BaseOperation;
+use DCorePHP\Model\NftDataType;
+use DCorePHP\Model\NftOptions;
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
+use InvalidArgumentException;
+
+class NftCreateOperation extends BaseOperation
+{
+    public const OPERATION_TYPE = 41;
+
+    /** @var string */
+    private $symbol;
+    /** @var NftOptions */
+    private $options;
+    /** @var NftDataType[] */
+    private $definitions;
+    /** @var bool */
+    private $transferable;
+
+    /**
+     * @return string
+     */
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    /**
+     * @param string $symbol
+     * @return NftCreateOperation
+     */
+    public function setSymbol(string $symbol): NftCreateOperation
+    {
+        if (!Asset::isValidSymbol($symbol)) throw new InvalidArgumentException("invalid nft symbol: $symbol");
+        $this->symbol = $symbol;
+
+        return $this;
+    }
+
+    /**
+     * @return NftOptions
+     */
+    public function getOptions(): NftOptions
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param NftOptions $options
+     * @return NftCreateOperation
+     * @throws ValidationException
+     */
+    public function setOptions(NftOptions $options): NftCreateOperation
+    {
+        if (strlen($options->getDescription()) > DCoreConstants::UIA_DESCRIPTION_MAX_CHARS) {
+            throw new InvalidArgumentException('description cannot be longer then ' . DCoreConstants::UIA_DESCRIPTION_MAX_CHARS . 'chars');
+        }
+        $options->validateMaxSupply();
+
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return NftDataType[]
+     */
+    public function getDefinitions(): array
+    {
+        return $this->definitions;
+    }
+
+    /**
+     * @param NftDataType[] $definitions
+     * @return NftCreateOperation
+     */
+    public function setDefinitions(array $definitions): NftCreateOperation
+    {
+//        foreach ($definitions as $definition) {
+//            $definition->validate();
+//        }
+        $this->definitions = $definitions;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTransferable(): bool
+    {
+        return $this->transferable;
+    }
+
+    /**
+     * @param bool $transferable
+     * @return NftCreateOperation
+     */
+    public function setTransferable(bool $transferable): NftCreateOperation
+    {
+        $this->transferable = $transferable;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            self::OPERATION_TYPE,
+            [
+                'symbol' => $this->getSymbol(),
+                'options' => $this->getOptions()->toArray(),
+                'definitions' => array_map(static function (NftDataType $data){ return $data->toArray(); }, $this->getDefinitions()),
+                'transferable' => $this->isTransferable(),
+                'fee' => $this->getFee()->toArray()
+            ]
+        ];
+    }
+
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getTypeBytes(),
+            $this->getFee()->toBytes(),
+            VarInt::encodeDecToHex(sizeof(Math::stringToByteArray($this->getSymbol()))),
+            Math::byteArrayToHex(Math::stringToByteArray($this->getSymbol())),
+            $this->getOptions()->toBytes(),
+            Math::getInt8(count($this->getDefinitions())), // number of definitions
+            $this->getDefinitions() ? implode('', array_map(static function (NftDataType $definition) { // operation bytes
+                return $definition->toBytes();
+            }, $this->getDefinitions())) : '00',
+            $this->isTransferable() ? '01' : '00',
+            '00'
+        ]);
+    }
+}

--- a/src/Model/Operation/NftIssueOperation.php
+++ b/src/Model/Operation/NftIssueOperation.php
@@ -151,7 +151,9 @@ class NftIssueOperation extends BaseOperation
                 'issuer' => $this->getIssuer()->getId(),
                 'nft_id' => $this->getId()->getId(),
                 'to' => $this->getTo()->getId(),
-                'data' => array_map(static function (Variant $variant) { return $variant->getValue(); }, $this->getData()),
+                'data' => array_map(static function (Variant $variant) {
+                        return $variant->getType() === 'integer' ? 'CASTTOINT-' . $variant->getValue() : $variant->getValue();
+                    }, $this->getData()),
                 'memo' => $this->getMemo() ? $this->getMemo()->toArray() : null,
                 'fee' => $this->getFee()->toArray()
             ]

--- a/src/Model/Operation/NftIssueOperation.php
+++ b/src/Model/Operation/NftIssueOperation.php
@@ -2,10 +2,15 @@
 
 namespace DCorePHP\Model\Operation;
 
+use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\BaseOperation;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Memo;
-use DCorePHP\Model\NftOptions;
+use DCorePHP\Model\NftDataType;
+use DCorePHP\Model\Variant;
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
+use Exception;
 
 class NftIssueOperation extends BaseOperation
 {
@@ -17,10 +22,159 @@ class NftIssueOperation extends BaseOperation
     private $id;
     /** @var ChainObject */
     private $to;
-    /** @var array */
+    /** @var Variant[] */
     private $data = [];
     /** @var Memo */
-    private $memo = null;
+    private $memo;
 
-    // TODO
+    /**
+     * @return ChainObject
+     */
+    public function getIssuer(): ChainObject
+    {
+        return $this->issuer;
+    }
+
+    /**
+     * @param ChainObject|string $issuer
+     *
+     * @return NftIssueOperation
+     * @throws ValidationException
+     */
+    public function setIssuer($issuer): NftIssueOperation
+    {
+        if (is_string($issuer)) {
+            $issuer = new ChainObject($issuer);
+        }
+        $this->issuer = $issuer;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject|string $id
+     *
+     * @return NftIssueOperation
+     * @throws ValidationException
+     */
+    public function setId($id): NftIssueOperation
+    {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getTo(): ChainObject
+    {
+        return $this->to;
+    }
+
+    /**
+     * @param ChainObject|string $to
+     *
+     * @return NftIssueOperation
+     * @throws ValidationException
+     */
+    public function setTo($to): NftIssueOperation
+    {
+        if (is_string($to)) {
+            $to = new ChainObject($to);
+        }
+        $this->to = $to;
+
+        return $this;
+    }
+
+    /**
+     * @return Variant[]
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param Variant[] $data
+     *
+     * @return NftIssueOperation
+     */
+    public function setData(array $data): NftIssueOperation
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return Memo
+     */
+    public function getMemo(): ?Memo
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param Memo $memo
+     *
+     * @return NftIssueOperation
+     */
+    public function setMemo(?Memo $memo): NftIssueOperation
+    {
+        $this->memo = $memo;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public function toArray(): array
+    {
+        return [
+            self::OPERATION_TYPE,
+            [
+                'issuer' => $this->getIssuer()->getId(),
+                'nft_id' => $this->getId()->getId(),
+                'to' => $this->getTo()->getId(),
+                'data' => array_map(static function (Variant $variant) { return $variant->getValue(); }, $this->getData()),
+                'memo' => $this->getMemo() ? $this->getMemo()->toArray() : null,
+                'fee' => $this->getFee()->toArray()
+            ]
+        ];
+    }
+
+    /**
+     * @return string
+     * @throws Exception
+     */
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getTypeBytes(),
+            $this->getFee()->toBytes(),
+            $this->getIssuer()->toBytes(),
+            $this->getTo()->toBytes(),
+            $this->getId()->toBytes(),
+            VarInt::encodeDecToHex(sizeof($this->getData())),
+            implode('', array_map(static function (Variant $element) { return $element->toBytes(); }, $this->getData())),
+            $this->getMemo() ? $this->getMemo()->toBytes() : '00',
+            '00'
+        ]);
+    }
+
 }

--- a/src/Model/Operation/NftIssueOperation.php
+++ b/src/Model/Operation/NftIssueOperation.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DCorePHP\Model\Operation;
+
+use DCorePHP\Model\BaseOperation;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\Memo;
+use DCorePHP\Model\NftOptions;
+
+class NftIssueOperation extends BaseOperation
+{
+    public const OPERATION_TYPE = 43;
+
+    /** @var ChainObject */
+    private $issuer;
+    /** @var ChainObject */
+    private $id;
+    /** @var ChainObject */
+    private $to;
+    /** @var array */
+    private $data = [];
+    /** @var Memo */
+    private $memo = null;
+
+    // TODO
+}

--- a/src/Model/Operation/NftTransferOperation.php
+++ b/src/Model/Operation/NftTransferOperation.php
@@ -2,10 +2,11 @@
 
 namespace DCorePHP\Model\Operation;
 
+use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\BaseOperation;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Memo;
-use DCorePHP\Model\NftOptions;
+use Exception;
 
 class NftTransferOperation extends BaseOperation
 {
@@ -18,7 +19,133 @@ class NftTransferOperation extends BaseOperation
     /** @var ChainObject */
     private $id;
     /** @var Memo */
-    private $memo = null;
+    private $memo;
 
-    // TODO
+    /**
+     * @return ChainObject
+     */
+    public function getFrom(): ChainObject
+    {
+        return $this->from;
+    }
+
+    /**
+     * @param ChainObject|string $from
+     *
+     * @return NftTransferOperation
+     * @throws ValidationException
+     */
+    public function setFrom($from): NftTransferOperation
+    {
+
+        if (is_string($from)) {
+            $from = new ChainObject($from);
+        }
+        $this->from = $from;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getTo(): ChainObject
+    {
+        return $this->to;
+    }
+
+    /**
+     * @param ChainObject|string $to
+     *
+     * @return NftTransferOperation
+     * @throws ValidationException
+     */
+    public function setTo($to): NftTransferOperation
+    {
+        if (is_string($to)) {
+            $to = new ChainObject($to);
+        }
+        $this->to = $to;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject|string $id
+     *
+     * @return NftTransferOperation
+     * @throws ValidationException
+     */
+    public function setId($id): NftTransferOperation
+    {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return Memo
+     */
+    public function getMemo(): ?Memo
+    {
+        return $this->memo;
+    }
+
+    /**
+     * @param Memo $memo
+     *
+     * @return NftTransferOperation
+     */
+    public function setMemo(?Memo $memo): NftTransferOperation
+    {
+        $this->memo = $memo;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public function toArray(): array
+    {
+        return [
+            self::OPERATION_TYPE,
+            [
+                'from' => $this->getFrom()->getId(),
+                'to' => $this->getTo()->getId(),
+                'nft_data_id' => $this->getId()->getId(),
+                'memo' => $this->getMemo() ? $this->getMemo()->toArray() : null,
+                'fee' => $this->getFee()->toArray()
+            ]
+        ];
+    }
+
+    /**
+     * @return string
+     * @throws Exception
+     */
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getTypeBytes(),
+            $this->getFee()->toBytes(),
+            $this->getFrom()->toBytes(),
+            $this->getTo()->toBytes(),
+            $this->getId()->toBytes(),
+            $this->getMemo() ? $this->getMemo()->toBytes() : '00',
+            '00'
+        ]);
+    }
 }

--- a/src/Model/Operation/NftTransferOperation.php
+++ b/src/Model/Operation/NftTransferOperation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DCorePHP\Model\Operation;
+
+use DCorePHP\Model\BaseOperation;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\Memo;
+use DCorePHP\Model\NftOptions;
+
+class NftTransferOperation extends BaseOperation
+{
+    public const OPERATION_TYPE = 44;
+
+    /** @var ChainObject */
+    private $from;
+    /** @var ChainObject */
+    private $to;
+    /** @var ChainObject */
+    private $id;
+    /** @var Memo */
+    private $memo = null;
+
+    // TODO
+}

--- a/src/Model/Operation/NftUpdateDataOperation.php
+++ b/src/Model/Operation/NftUpdateDataOperation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DCorePHP\Model\Operation;
+
+use DCorePHP\Model\BaseOperation;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\NftOptions;
+
+class NftUpdateDataOperation extends BaseOperation
+{
+    public const OPERATION_TYPE = 45;
+
+    /** @var ChainObject */
+    private $modifier;
+    /** @var ChainObject */
+    private $id;
+    /** @var array */
+    private $data;
+
+    // TODO
+}

--- a/src/Model/Operation/NftUpdateDataOperation.php
+++ b/src/Model/Operation/NftUpdateDataOperation.php
@@ -5,6 +5,9 @@ namespace DCorePHP\Model\Operation;
 use DCorePHP\Model\BaseOperation;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\NftOptions;
+use DCorePHP\Model\Variant;
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
 
 class NftUpdateDataOperation extends BaseOperation
 {
@@ -17,5 +20,104 @@ class NftUpdateDataOperation extends BaseOperation
     /** @var array */
     private $data;
 
-    // TODO
+    /**
+     * @return ChainObject
+     */
+    public function getModifier(): ChainObject
+    {
+        return $this->modifier;
+    }
+
+    /**
+     * @param ChainObject $modifier
+     *
+     * @return NftUpdateDataOperation
+     */
+    public function setModifier(ChainObject $modifier): NftUpdateDataOperation
+    {
+        $this->modifier = $modifier;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject $id
+     *
+     * @return NftUpdateDataOperation
+     */
+    public function setId(ChainObject $id): NftUpdateDataOperation
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return NftUpdateDataOperation
+     */
+    public function setData(array $data): NftUpdateDataOperation
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            self::OPERATION_TYPE,
+            [
+                'modifier' => $this->getModifier()->getId(),
+                'nft_data_id' => $this->getId()->getId(),
+                'data' => $this->getDataAsArray(),
+                'fee' => $this->getFee()->toArray(),
+            ],
+        ];
+    }
+
+    private function getDataAsArray(): array
+    {
+        $result = [];
+        /** @var Variant $variant */
+        foreach ($this->getData() as $variant) {
+            $result[] = [$variant->getName(), $variant->getValue()];
+        }
+        return $result;
+    }
+
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getTypeBytes(),
+            $this->getFee()->toBytes(),
+            $this->getModifier()->toBytes(),
+            $this->getId()->toBytes(),
+            VarInt::encodeDecToHex(sizeof($this->getData())),
+            implode('', array_map(static function (Variant $element) {
+                return implode('', [
+                    VarInt::encodeDecToHex(sizeof(Math::stringToByteArray($element->getName()))),
+                    Math::byteArrayToHex(Math::stringToByteArray($element->getName())),
+                    $element->toBytes()]);
+                }, $this->getData())),
+            '00',
+        ]);
+    }
 }

--- a/src/Model/Operation/NftUpdateOperation.php
+++ b/src/Model/Operation/NftUpdateOperation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DCorePHP\Model\Operation;
+
+use DCorePHP\Model\BaseOperation;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\NftOptions;
+
+class NftUpdateOperation extends BaseOperation
+{
+    public const OPERATION_TYPE = 42;
+
+    /** @var ChainObject */
+    private $issuer;
+    /** @var ChainObject */
+    private $id;
+    /** @var NftOptions */
+    private $options;
+
+    // TODO
+}

--- a/src/Model/Operation/NftUpdateOperation.php
+++ b/src/Model/Operation/NftUpdateOperation.php
@@ -2,9 +2,12 @@
 
 namespace DCorePHP\Model\Operation;
 
+use DCorePHP\DCoreConstants;
+use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\BaseOperation;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\NftOptions;
+use InvalidArgumentException;
 
 class NftUpdateOperation extends BaseOperation
 {
@@ -17,5 +20,99 @@ class NftUpdateOperation extends BaseOperation
     /** @var NftOptions */
     private $options;
 
-    // TODO
+    /**
+     * @return ChainObject
+     */
+    public function getIssuer(): ChainObject
+    {
+        return $this->issuer;
+    }
+
+    /**
+     * @param ChainObject|string $issuer
+     * @return NftUpdateOperation
+     * @throws ValidationException
+     */
+    public function setIssuer($issuer): NftUpdateOperation
+    {
+        if (is_string($issuer)) {
+            $issuer = new ChainObject($issuer);
+        }
+        $this->issuer = $issuer;
+
+        return $this;
+    }
+
+    /**
+     * @return ChainObject
+     */
+    public function getId(): ChainObject
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param ChainObject|string $id
+     * @return NftUpdateOperation
+     * @throws ValidationException
+     */
+    public function setId($id): NftUpdateOperation
+    {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return NftOptions
+     */
+    public function getOptions(): NftOptions
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param NftOptions $options
+     * @return NftUpdateOperation
+     * @throws ValidationException
+     */
+    public function setOptions(NftOptions $options): NftUpdateOperation
+    {
+        if (strlen($options->getDescription()) > DCoreConstants::UIA_DESCRIPTION_MAX_CHARS) {
+            throw new InvalidArgumentException('description cannot be longer then ' . DCoreConstants::UIA_DESCRIPTION_MAX_CHARS . 'chars');
+        }
+        $options->validateMaxSupply();
+
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            self::OPERATION_TYPE,
+            [
+                'current_issuer' => $this->getIssuer()->getId(),
+                'nft_id' => $this->getId()->getId(),
+                'options' => $this->getOptions()->toArray(),
+                'fee' => $this->getFee()->toArray()
+            ]
+        ];
+    }
+
+    public function toBytes(): string
+    {
+        return implode('', [
+            $this->getTypeBytes(),
+            $this->getFee()->toBytes(),
+            $this->getIssuer()->toBytes(),
+            $this->getId()->toBytes(),
+            $this->getOptions()->toBytes(),
+            '00'
+        ]);
+    }
 }

--- a/src/Model/OperationFactory.php
+++ b/src/Model/OperationFactory.php
@@ -2,6 +2,8 @@
 
 namespace DCorePHP\Model;
 
+use DCorePHP\Model\Operation\NftCreateOperation;
+use DCorePHP\Model\Operation\NftUpdateOperation;
 use DCorePHP\Model\Operation\UnknownOperation;
 
 class OperationFactory
@@ -52,7 +54,12 @@ class OperationFactory
             37 => 'update_monitored_asset_operation',
             Operation\ReadyToPublish2Operation::OPERATION_TYPE => Operation\ReadyToPublish2Operation::class,
             Operation\Transfer2::OPERATION_TYPE => Operation\Transfer2::class,
-            Operation\AssetUpdateAdvancedOperation::OPERATION_TYPE => Operation\AssetUpdateAdvancedOperation::class
+            Operation\AssetUpdateAdvancedOperation::OPERATION_TYPE => Operation\AssetUpdateAdvancedOperation::class,
+            Operation\NftCreateOperation::OPERATION_TYPE => Operation\NftCreateOperation::class,
+            Operation\NftUpdateOperation::OPERATION_TYPE => Operation\NftUpdateOperation::class,
+            Operation\NftIssueOperation::OPERATION_TYPE => Operation\NftIssueOperation::class,
+            Operation\NftTransferOperation::OPERATION_TYPE => Operation\NftTransferOperation::class,
+            Operation\NftUpdateDataOperation::OPERATION_TYPE => Operation\NftUpdateDataOperation::class
         ];
     }
 

--- a/src/Model/ProcessedTransaction.php
+++ b/src/Model/ProcessedTransaction.php
@@ -139,7 +139,7 @@ class ProcessedTransaction
     /**
      * @return array
      */
-    public function getOpResults(): array
+    public function getOpResults(): ?array
     {
         return $this->opResults;
     }

--- a/src/Model/TransactionDetail.php
+++ b/src/Model/TransactionDetail.php
@@ -2,15 +2,18 @@
 
 namespace DCorePHP\Model;
 
+use DateTime;
+use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\Asset\AssetAmount;
+use Exception;
 
 class TransactionDetail
 {
-    /** @var string */
+    /** @var ChainObject */
     private $id;
-    /** @var string */
+    /** @var ChainObject */
     private $from;
-    /** @var string */
+    /** @var ChainObject */
     private $to;
     /** @var int */
     private $type;
@@ -18,9 +21,11 @@ class TransactionDetail
     private $amount;
     /** @var AssetAmount */
     private $fee;
+    /** @var ChainObject */
+    private $nftDataId;
     /** @var string */
     private $description;
-    /** @var \DateTime */
+    /** @var DateTime */
     private $timestamp;
 
     public function __construct()
@@ -30,55 +35,70 @@ class TransactionDetail
     }
 
     /**
-     * @return string
+     * @return ChainObject
      */
-    public function getId(): string
+    public function getId(): ChainObject
     {
         return $this->id;
     }
 
     /**
-     * @param string $id
+     * @param ChainObject|string $id
+     *
      * @return TransactionDetail
+     * @throws ValidationException
      */
-    public function setId(string $id): TransactionDetail
+    public function setId($id): TransactionDetail
     {
+        if (is_string($id)) {
+            $id = new ChainObject($id);
+        }
         $this->id = $id;
         return $this;
     }
 
     /**
-     * @return string
+     * @return ChainObject
      */
-    public function getFrom(): string
+    public function getFrom(): ChainObject
     {
         return $this->from;
     }
 
     /**
-     * @param string $from
+     * @param ChainObject|string $from
+     *
      * @return TransactionDetail
+     * @throws ValidationException
      */
     public function setFrom(string $from): TransactionDetail
     {
+        if (is_string($from)) {
+            $from = new ChainObject($from);
+        }
         $this->from = $from;
         return $this;
     }
 
     /**
-     * @return string
+     * @return ChainObject
      */
-    public function getTo(): string
+    public function getTo(): ChainObject
     {
         return $this->to;
     }
 
     /**
-     * @param string $to
+     * @param ChainObject|string $to
+     *
      * @return TransactionDetail
+     * @throws ValidationException
      */
-    public function setTo(string $to): TransactionDetail
+    public function setTo($to): TransactionDetail
     {
+        if (is_string($to)) {
+            $to = new ChainObject($to);
+        }
         $this->to = $to;
         return $this;
     }
@@ -138,6 +158,30 @@ class TransactionDetail
     }
 
     /**
+     * @return ChainObject
+     */
+    public function getNftDataId(): ChainObject
+    {
+        return $this->nftDataId;
+    }
+
+    /**
+     * @param ChainObject|string $nftDataId
+     *
+     * @return TransactionDetail
+     * @throws ValidationException
+     */
+    public function setNftDataId($nftDataId): TransactionDetail
+    {
+        if (is_string($nftDataId)) {
+            $nftDataId = new ChainObject($nftDataId);
+        }
+        $this->nftDataId = $nftDataId;
+
+        return $this;
+    }
+
+    /**
      * @return string
      */
     public function getDescription(): string
@@ -156,20 +200,22 @@ class TransactionDetail
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
-    public function getTimestamp(): \DateTime
+    public function getTimestamp(): DateTime
     {
         return $this->timestamp;
     }
 
     /**
-     * @param \DateTime|string $timestamp
+     * @param DateTime|string $timestamp
+     *
      * @return TransactionDetail
+     * @throws Exception
      */
     public function setTimestamp($timestamp): TransactionDetail
     {
-        $this->timestamp = $timestamp instanceof \DateTime ? $timestamp : new \DateTime($timestamp);
+        $this->timestamp = $timestamp instanceof DateTime ? $timestamp : new DateTime($timestamp);
         return $this;
     }
 }

--- a/src/Model/Variant.php
+++ b/src/Model/Variant.php
@@ -17,17 +17,21 @@ class Variant
     private $type;
     /** @var mixed */
     private $value;
+    /** @var string */
+    private $name;
 
     /**
      * Variant constructor.
      *
      * @param string $type
      * @param mixed $value
+     * @param string $name
      */
-    public function __construct(string $type, $value)
+    public function __construct(string $type, $value, string $name = null)
     {
         $this->type = $type;
         $this->value = $value;
+        $this->name = $name;
     }
 
     /**
@@ -66,6 +70,26 @@ class Variant
     public function setValue($value): Variant
     {
         $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Variant
+     */
+    public function setName(string $name): Variant
+    {
+        $this->name = $name;
 
         return $this;
     }

--- a/src/Model/Variant.php
+++ b/src/Model/Variant.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace DCorePHP\Model;
+
+use DCorePHP\Utils\Math;
+use DCorePHP\Utils\VarInt;
+use InvalidArgumentException;
+
+class Variant
+{
+    public const INT64_TYPE = 1;
+    public const UINT64_TYPE = 2;
+    public const BOOL_TYPE = 4;
+    public const STRING_TYPE = 5;
+
+    /** @var string */
+    private $type;
+    /** @var mixed */
+    private $value;
+
+    /**
+     * Variant constructor.
+     *
+     * @param string $type
+     * @param mixed $value
+     */
+    public function __construct(string $type, $value)
+    {
+        $this->type = $type;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return Variant
+     */
+    public function setType($type): Variant
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Variant
+     */
+    public function setValue($value): Variant
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function toBytes(): string {
+        switch ($this->getType()) {
+            case 'integer':
+                $type = gmp_cmp($this->getValue(), 0) >= 0 ? self::UINT64_TYPE : self::INT64_TYPE;
+                $result = [
+                    '0' . $type,
+                    Math::getInt64($this->getValue())
+                ];
+                break;
+            case 'boolean':
+                $result = [
+                    '0' . self::BOOL_TYPE,
+                    $this->getValue() ? '01' : '00',
+                ];
+                break;
+            case 'string':
+                $result = [
+                    '0' . self::STRING_TYPE,
+                    VarInt::encodeDecToHex(sizeof(Math::stringToByteArray($this->getValue()))),
+                    Math::byteArrayToHex(Math::stringToByteArray($this->getValue())),
+                ];
+                break;
+            default:
+                throw new InvalidArgumentException("Type '$this->type' is not allowed!");
+        }
+        return implode('', $result);
+    }
+}

--- a/src/Net/Model/Request/BaseRequest.php
+++ b/src/Net/Model/Request/BaseRequest.php
@@ -14,6 +14,7 @@ abstract class BaseRequest
     public const API_GROUP_HISTORY = 3;
     public const API_GROUP_CRYPTO = 4;
     public const API_GROUP_MESSAGING = 5;
+    private const CAST_TO_INT_FLAG = '/"CASTTOINT-([^"]+)"/';
 
     /** @var int */
     protected $apiGroup;
@@ -106,7 +107,7 @@ abstract class BaseRequest
 
     public function toJson(): string
     {
-        return json_encode([
+        $json = json_encode([
             'jsonrpc' => $this->jsonrpc,
             'id' => $this->id,
             'method' => 'call',
@@ -116,6 +117,7 @@ abstract class BaseRequest
                 $this->params
             ],
         ]);
+        return preg_replace(self::CAST_TO_INT_FLAG, '${1}', $json);
     }
 
     abstract public static function responseToModel(BaseResponse $response);

--- a/src/Net/Model/Request/BroadcastTransactionWithCallback.php
+++ b/src/Net/Model/Request/BroadcastTransactionWithCallback.php
@@ -40,7 +40,7 @@ class BroadcastTransactionWithCallback extends BaseRequest
                 '[trx][ref_block_num]' => 'transaction.refBlockNum',
                 '[trx][ref_block_prefix]' => 'transaction.refBlockPrefix',
                 '[trx][expiration]' => 'transaction.expiration',
-                // TODO: opResults
+                '[trx][operation_results]' => 'transaction.opResults'
             ] as $path => $modelPath
         ) {
             $value = self::getPropertyAccessor()->getValue($rawTrxConf, $path);

--- a/src/Net/Model/Request/GetNftAbstract.php
+++ b/src/Net/Model/Request/GetNftAbstract.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Model\Nft;
+use DCorePHP\Model\NftDataType;
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+abstract class GetNftAbstract extends BaseRequest
+{
+    public static function responseToModel(BaseResponse $response)
+    {
+        return self::resultToModel($response->getResult());
+    }
+
+    protected static function resultToModel(array $result)
+    {
+        $nft = new Nft();
+
+        foreach (
+            [
+                '[id]' => 'id',
+                '[symbol]' => 'symbol',
+                '[options][issuer]' => 'options.issuer',
+                '[options][max_supply]' => 'options.maxSupply',
+                '[options][fixed_max_supply]' => 'options.fixedMaxSupply',
+                '[options][description]' => 'options.description',
+                '[transferable]' => 'transferable',
+                '[current_supply]' => 'currentSupply'
+            ] as $path => $modelPath
+        ) {
+            $value = self::getPropertyAccessor()->getValue($result, $path);
+            self::getPropertyAccessor()->setValue($nft, $modelPath, $value);
+        }
+
+        $definitions = [];
+        foreach ($result['definitions'] as $rawDefinition) {
+            $definition = new NftDataType();
+            foreach (
+                [
+                    '[unique]' => 'unique',
+                    '[modifiable]' => 'modifiable',
+                    '[type]' => 'type',
+                    '[name]' => 'name',
+                ] as $path => $modelPath
+            ) {
+                $value = self::getPropertyAccessor()->getValue($rawDefinition, $path);
+                self::getPropertyAccessor()->setValue($definition, $modelPath, $value);
+            }
+            $definitions[] = $definition;
+        }
+        $nft->setDefinitions($definitions);
+
+        return $nft;
+    }
+}

--- a/src/Net/Model/Request/GetNftCount.php
+++ b/src/Net/Model/Request/GetNftCount.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class GetNftCount extends BaseRequest
+{
+    public function __construct()
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'get_non_fungible_token_count'
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        return $response->getResult();
+    }
+}

--- a/src/Net/Model/Request/GetNftData.php
+++ b/src/Net/Model/Request/GetNftData.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class GetNftData extends BaseRequest
+{
+    public function __construct(array $ids)
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'get_non_fungible_token_data',
+            [array_map(static function (ChainObject $id) { return $id->getId(); }, $ids)]
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        dump($response->getResult());
+        // TODO: Implement responseToModel() method.
+    }
+}

--- a/src/Net/Model/Request/GetNftData.php
+++ b/src/Net/Model/Request/GetNftData.php
@@ -3,6 +3,7 @@
 namespace DCorePHP\Net\Model\Request;
 
 use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\NftData;
 use DCorePHP\Net\Model\Response\BaseResponse;
 
 class GetNftData extends BaseRequest
@@ -16,9 +17,26 @@ class GetNftData extends BaseRequest
         );
     }
 
-    public static function responseToModel(BaseResponse $response)
+    public static function responseToModel(BaseResponse $response): array
     {
-        dump($response->getResult());
-        // TODO: Implement responseToModel() method.
+        $data = [];
+        foreach ($response->getResult() as $result) {
+            $nftData = new NftData();
+            foreach (
+                [
+                    '[id]' => 'id',
+                    '[nft_id]' => 'nftId',
+                    '[owner]' => 'owner',
+                    '[data]' => 'data'
+                ] as $path => $modelPath
+            ) {
+                $value = self::getPropertyAccessor()->getValue($result, $path);
+                self::getPropertyAccessor()->setValue($nftData, $modelPath, $value);
+            }
+
+            $data[] = $nftData;
+        }
+
+        return $data;
     }
 }

--- a/src/Net/Model/Request/GetNftDataAbstract.php
+++ b/src/Net/Model/Request/GetNftDataAbstract.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Model\NftData;
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+abstract class GetNftDataAbstract extends BaseRequest
+{
+    public static function responseToModel(BaseResponse $response)
+    {
+        return self::resultToModel($response->getResult());
+    }
+
+    public static function resultToModel(array $result)
+    {
+        $nftData = new NftData();
+        foreach (
+            [
+                '[id]' => 'id',
+                '[nft_id]' => 'nftId',
+                '[owner]' => 'owner',
+                '[data]' => 'data'
+            ] as $path => $modelPath
+        ) {
+            $value = self::getPropertyAccessor()->getValue($result, $path);
+            self::getPropertyAccessor()->setValue($nftData, $modelPath, $value);
+        }
+        return $nftData;
+    }
+}

--- a/src/Net/Model/Request/GetNftDataCount.php
+++ b/src/Net/Model/Request/GetNftDataCount.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class GetNftDataCount extends BaseRequest
+{
+    public function __construct()
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'get_non_fungible_token_data_count'
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        return $response->getResult();
+    }
+}

--- a/src/Net/Model/Request/GetNfts.php
+++ b/src/Net/Model/Request/GetNfts.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class GetNfts extends GetNftAbstract
+{
+    public function __construct(array $ids)
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'get_non_fungible_tokens',
+            [array_map(static function (ChainObject $id) { return $id->getId(); }, $ids)]
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        $nfts = [];
+        foreach ($response->getResult() as $rawNft) {
+            if ($rawNft === null) {
+                $nfts[] = null;
+                continue;
+            }
+            $nfts[] = parent::resultToModel($rawNft);
+        }
+
+        return $nfts;
+    }
+}

--- a/src/Net/Model/Request/GetNftsBalances.php
+++ b/src/Net/Model/Request/GetNftsBalances.php
@@ -5,18 +5,18 @@ namespace DCorePHP\Net\Model\Request;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Net\Model\Response\BaseResponse;
 
-class GetNftData extends GetNftDataAbstract
+class GetNftsBalances extends GetNftDataAbstract
 {
-    public function __construct(array $ids)
+    public function __construct(ChainObject $account, array $nftIds)
     {
         parent::__construct(
             self::API_GROUP_DATABASE,
-            'get_non_fungible_token_data',
-            [array_map(static function (ChainObject $id) { return $id->getId(); }, $ids)]
+            'get_non_fungible_token_balances',
+            [$account->getId(), array_map(static function (ChainObject $id) { return $id->getId(); }, $nftIds)]
         );
     }
 
-    public static function responseToModel(BaseResponse $response): array
+    public static function responseToModel(BaseResponse $response)
     {
         $nfts = [];
         foreach ($response->getResult() as $rawNft) {

--- a/src/Net/Model/Request/GetNftsBySymbol.php
+++ b/src/Net/Model/Request/GetNftsBySymbol.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class GetNftsBySymbol extends GetNftAbstract
+{
+    public function __construct(array $symbols)
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'get_non_fungible_tokens_by_symbols',
+            [$symbols]
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        $nfts = [];
+        foreach ($response->getResult() as $rawNft) {
+            if ($rawNft === null) {
+                $nfts[] = null;
+                continue;
+            }
+            $nfts[] = parent::resultToModel($rawNft);
+        }
+
+        return $nfts;
+    }
+}

--- a/src/Net/Model/Request/ListNftData.php
+++ b/src/Net/Model/Request/ListNftData.php
@@ -5,14 +5,14 @@ namespace DCorePHP\Net\Model\Request;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Net\Model\Response\BaseResponse;
 
-class GetNftData extends GetNftDataAbstract
+class ListNftData extends GetNftDataAbstract
 {
-    public function __construct(array $ids)
+    public function __construct(ChainObject $nftId)
     {
         parent::__construct(
             self::API_GROUP_DATABASE,
-            'get_non_fungible_token_data',
-            [array_map(static function (ChainObject $id) { return $id->getId(); }, $ids)]
+            'list_non_fungible_token_data',
+            [$nftId->getId()]
         );
     }
 

--- a/src/Net/Model/Request/ListNfts.php
+++ b/src/Net/Model/Request/ListNfts.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DCorePHP\Net\Model\Request;
+
+use DCorePHP\Net\Model\Response\BaseResponse;
+
+class ListNfts extends GetNftAbstract
+{
+    public function __construct(string $lowerBound, int $limit)
+    {
+        parent::__construct(
+            self::API_GROUP_DATABASE,
+            'list_non_fungible_tokens',
+            [$lowerBound, $limit]
+        );
+    }
+
+    public static function responseToModel(BaseResponse $response)
+    {
+        $nfts = [];
+        foreach ($response->getResult() as $result) {
+            $nfts[] = self::resultToModel($result);
+        }
+        return $nfts;
+    }
+}

--- a/src/Net/Model/Request/SearchNftHistory.php
+++ b/src/Net/Model/Request/SearchNftHistory.php
@@ -2,48 +2,22 @@
 
 namespace DCorePHP\Net\Model\Request;
 
-use DCorePHP\Model\Account;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\TransactionDetail;
 use DCorePHP\Net\Model\Response\BaseResponse;
 
-class SearchAccountHistory extends BaseRequest
+class SearchNftHistory extends BaseRequest
 {
-    public const ORDER_TYPE_ASC = '+type';
-    public const ORDER_TO_ASC = '+to';
-    public const ORDER_FROM_ASC = '+from';
-    public const ORDER_PRICE_ASC = '+price';
-    public const ORDER_FEE_ASC = '+fee';
-    public const ORDER_DESCRIPTION_ASC = '+description';
-    public const ORDER_TIME_ASC = '+time';
-    public const ORDER_TYPE_DESC = '-type';
-    public const ORDER_TO_DESC = '-to';
-    public const ORDER_FROM_DESC = '-from';
-    public const ORDER_PRICE_DESC = '-price';
-    public const ORDER_FEE_DESC = '-fee';
-    public const ORDER__DESCRIPTION_DESC = '-description';
-    public const ORDER_TIME_DESC = '-time';
-
-    /**
-     * @param ChainObject $accountId
-     * @param string $order
-     * @param string $startObjectId
-     * @param int $limit
-     */
-    public function __construct(ChainObject $accountId, string $order = self::ORDER_TIME_DESC, string $startObjectId = '0.0.0', int $limit = 100)
+    public function __construct(ChainObject $nftDataId)
     {
         parent::__construct(
             self::API_GROUP_DATABASE,
-            'search_account_history',
-            [$accountId->getId(), $order, $startObjectId, $limit]
+            'search_non_fungible_token_history',
+            [$nftDataId->getId()]
         );
     }
 
-    /**
-     * @param BaseResponse $response
-     * @return Account[]
-     */
-    public static function responseToModel(BaseResponse $response): array
+    public static function responseToModel(BaseResponse $response)
     {
         $transactionDetails = [];
         foreach ($response->getResult() as $rawTransaction) {

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace DCorePHP\Sdk;
+
+use DCorePHP\Crypto\Credentials;
+use DCorePHP\DCoreApi;
+use DCorePHP\Exception\ObjectNotFoundException;
+use DCorePHP\Model\Asset\AssetAmount;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\Memo;
+use DCorePHP\Model\Nft;
+use DCorePHP\Model\NftData;
+use DCorePHP\Model\NftOptions;
+use DCorePHP\Model\Operation\NftCreateOperation;
+use DCorePHP\Model\Proposal\Fee;
+use DCorePHP\Model\TransactionConfirmation;
+use DCorePHP\Net\Model\Request\GetNftData;
+use DCorePHP\Net\Model\Request\GetNfts;
+use DCorePHP\Net\Model\Request\GetNftsBySymbol;
+
+class NftApi extends BaseApi implements NftApiInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $idOrSymbol): Nft
+    {
+        if (ChainObject::isValid($idOrSymbol)) {
+            return $this->getById(new ChainObject($idOrSymbol));
+        }
+        return $this->getBySymbol($idOrSymbol);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAll(array $ids): array
+    {
+        return $this->dcoreApi->requestWebsocket(new GetNfts($ids));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getById(ChainObject $id): Nft
+    {
+        $nfts = $this->getAll([$id]);
+        $nft = reset($nfts);
+
+        if ($nft instanceof Nft) {
+            return $nft;
+        }
+
+        throw new ObjectNotFoundException("Nft with id $id doesn't exist.");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAllBySymbol(array $symbols): array
+    {
+        return $this->dcoreApi->requestWebsocket(new GetNftsBySymbol($symbols));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBySymbol(string $symbol): Nft
+    {
+        $nfts = $this->getAllBySymbol([$symbol]);
+        $nft = reset($nfts);
+
+        if ($nft instanceof Nft) {
+            return $nft;
+        }
+
+        throw new ObjectNotFoundException("Nft with symbol $symbol doesn't exist.");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAllData(array $ids): array
+    {
+        // TODO: Implement getAllData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAllDataRaw(array $ids): array
+    {
+        return $this->dcoreApi->requestWebsocket(new GetNftData($ids));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData(ChainObject $id): NftData
+    {
+        // TODO: Implement getData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDataRaw(ChainObject $id): NftData
+    {
+        // TODO: Implement getDataRaw() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function countAll(): string
+    {
+        // TODO: Implement countAll() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function countAllData(): string
+    {
+        // TODO: Implement countAllData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNftBalancesRaw(ChainObject $account, array $nftIds = []): array
+    {
+        // TODO: Implement getNftBalancesRaw() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNftBalances(ChainObject $account, array $nftIds = []): array
+    {
+        // TODO: Implement getNftBalances() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function listAllRelative(string $lowerBound = '', int $limit = DCoreApi::REQ_LIMIT_MAX): array
+    {
+        // TODO: Implement listAllRelative() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function listDataByNft(ChainObject $nftId): array
+    {
+        // TODO: Implement listDataByNft() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function listDataByNftRaw(ChainObject $nftId): array
+    {
+        // TODO: Implement listDataByNftRaw() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function searchNftHistory(ChainObject $nftDataId): array
+    {
+        // TODO: Implement searchNftHistory() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createNftCreateOperation(
+        string $symbol,
+        NftOptions $options,
+        $model,
+        bool $transferable,
+        $fee = null
+    ): NftCreateOperation {
+        $operation = new NftCreateOperation();
+        $operation
+            ->setSymbol($symbol)
+            ->setOptions($options)
+            ->setDefinitions($model)
+            ->setTransferable($transferable)
+            ->setFee($fee);
+        return $operation;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create(
+        Credentials $credentials,
+        string $symbol,
+        string $maxSupply,
+        bool $fixedMaxSupply,
+        string $description,
+        $model,
+        bool $transferable,
+        $fee = null
+    ): TransactionConfirmation {
+        $fee = $fee ?: new AssetAmount();
+        $options = new NftOptions();
+        $options
+            ->setIssuer($credentials->getAccount())
+            ->setMaxSupply($maxSupply)
+            ->setFixedMaxSupply($fixedMaxSupply)
+            ->setDescription($description);
+
+        return $this->dcoreApi->getBroadcastApi()->broadcastOperationWithECKeyPairWithCallback(
+            $credentials->getKeyPair(),
+            $this->createNftCreateOperation($symbol, $options, $model, $transferable, $fee)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createUpdateOperation(string $idOrSymbol, Fee $fee = null): NftUpdateOperation
+    {
+        // TODO: Implement createUpdateOperation() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(
+        Credentials $credentials,
+        string $idOrSymbol,
+        string $maxSupply = null,
+        bool $fixedMaxSupply = null,
+        string $description = null,
+        Fee $fee = null
+    ): TransactionConfirmation {
+        // TODO: Implement update() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createIssueOperation(
+        ChainObject $issuer,
+        string $idOrSymbol,
+        ChainObject $to,
+        $data = null,
+        Memo $memo = null,
+        Fee $fee = null
+    ): NftIssueOperation {
+        // TODO: Implement createIssueOperation() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function issue(
+        Credentials $credentials,
+        string $idOrSymbol,
+        ChainObject $to,
+        $data = null,
+        Memo $memo = null,
+        Fee $fee = null
+    ): TransactionConfirmation {
+        // TODO: Implement issue() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createTransferOperation(
+        ChainObject $from,
+        ChainObject $to,
+        ChainObject $id,
+        Memo $memo = null,
+        Fee $fee = null
+    ): NftOperation {
+        // TODO: Implement createTransferOperation() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function transfer(
+        Credentials $credentials,
+        ChainObject $to,
+        ChainObject $from,
+        Memo $memo = null,
+        Fee $fee = null
+    ): TransactionConfirmation {
+        // TODO: Implement transfer() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createUpdateDataOperation(
+        ChainObject $modifier,
+        ChainObject $id,
+        Fee $fee = null
+    ): NftUpdateDataOperation {
+        // TODO: Implement createUpdateDataOperation() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createUpdateDataOperationWithNewData(
+        ChainObject $modifier,
+        ChainObject $id,
+        $newData,
+        Fee $fee = null
+    ): NftUpdateDataOperation {
+        // TODO: Implement createUpdateDataOperationWithNewData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateData(
+        Credentials $credentials,
+        ChainObject $id,
+        array $values,
+        Fee $fee = null
+    ): TransactionConfirmation {
+        // TODO: Implement updateData() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDataWithNewData(
+        Credentials $credentials,
+        ChainObject $id,
+        $newData,
+        Fee $fee = null
+    ): TransactionConfirmation {
+        // TODO: Implement updateDataWithNewData() method.
+    }
+}

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -91,7 +91,7 @@ class NftApi extends BaseApi implements NftApiInterface
      */
     public function getAllData(array $ids): array
     {
-        // TODO: Implement getAllData() method.
+        return $this->make($this->dcoreApi->requestWebsocket(new GetNftData($ids)));
     }
 
     /**
@@ -403,5 +403,15 @@ class NftApi extends BaseApi implements NftApiInterface
         Fee $fee = null
     ): TransactionConfirmation {
         // TODO: Implement updateDataWithNewData() method.
+    }
+
+    private function make(array $data) {
+        return array_map(function (NftData $nft) {
+            $class = $this->dcoreApi->isRegistered($nft->getNftId()->getId());
+            if ($class) {
+                return NftData::init($nft, $class);
+            }
+            return null;
+        }, $data);
     }
 }

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -327,9 +327,16 @@ class NftApi extends BaseApi implements NftApiInterface
         ChainObject $to,
         ChainObject $id,
         Memo $memo = null,
-        Fee $fee = null
+        $fee = null
     ): NftTransferOperation {
-        // TODO: Implement createTransferOperation() method.
+        $operation = new NftTransferOperation();
+        $operation
+            ->setFrom($from)
+            ->setTo($to)
+            ->setId($id)
+            ->setMemo($memo)
+            ->setFee($fee);
+        return $operation;
     }
 
     /**
@@ -338,11 +345,16 @@ class NftApi extends BaseApi implements NftApiInterface
     public function transfer(
         Credentials $credentials,
         ChainObject $to,
-        ChainObject $from,
+        ChainObject $id,
         Memo $memo = null,
-        Fee $fee = null
+        $fee = null
     ): TransactionConfirmation {
-        // TODO: Implement transfer() method.
+        $fee = $fee ?: new AssetAmount();
+
+        return $this->dcoreApi->getBroadcastApi()->broadcastOperationWithECKeyPairWithCallback(
+            $credentials->getKeyPair(),
+            $this->createTransferOperation($credentials->getAccount(), $to, $id, $memo, $fee)
+        );
     }
 
     /**

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -24,6 +24,7 @@ use DCorePHP\Net\Model\Request\GetNftData;
 use DCorePHP\Net\Model\Request\GetNftDataCount;
 use DCorePHP\Net\Model\Request\GetNfts;
 use DCorePHP\Net\Model\Request\GetNftsBySymbol;
+use DCorePHP\Net\Model\Request\ListNfts;
 
 class NftApi extends BaseApi implements NftApiInterface
 {
@@ -165,7 +166,7 @@ class NftApi extends BaseApi implements NftApiInterface
      */
     public function listAllRelative(string $lowerBound = '', int $limit = DCoreApi::REQ_LIMIT_MAX): array
     {
-        // TODO: Implement listAllRelative() method.
+        return $this->dcoreApi->requestWebsocket(new ListNfts($lowerBound, $limit));
     }
 
     /**

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -10,11 +10,18 @@ use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Memo;
 use DCorePHP\Model\Nft;
 use DCorePHP\Model\NftData;
+use DCorePHP\Model\NftModel;
 use DCorePHP\Model\NftOptions;
 use DCorePHP\Model\Operation\NftCreateOperation;
+use DCorePHP\Model\Operation\NftIssueOperation;
+use DCorePHP\Model\Operation\NftTransferOperation;
+use DCorePHP\Model\Operation\NftUpdateDataOperation;
+use DCorePHP\Model\Operation\NftUpdateOperation;
 use DCorePHP\Model\Proposal\Fee;
 use DCorePHP\Model\TransactionConfirmation;
+use DCorePHP\Net\Model\Request\GetNftCount;
 use DCorePHP\Net\Model\Request\GetNftData;
+use DCorePHP\Net\Model\Request\GetNftDataCount;
 use DCorePHP\Net\Model\Request\GetNfts;
 use DCorePHP\Net\Model\Request\GetNftsBySymbol;
 
@@ -107,7 +114,18 @@ class NftApi extends BaseApi implements NftApiInterface
      */
     public function getDataRaw(ChainObject $id): NftData
     {
-        // TODO: Implement getDataRaw() method.
+        $dataArray = $this->getAllDataRaw([$id]);
+        $data = reset($nfts);
+
+        return $data;
+
+        // TODO
+
+//        if ($data instanceof Nft) {
+//            return $data;
+//        }
+
+//        throw new ObjectNotFoundException("Nft with symbol $id doesn't exist.");
     }
 
     /**
@@ -115,7 +133,7 @@ class NftApi extends BaseApi implements NftApiInterface
      */
     public function countAll(): string
     {
-        // TODO: Implement countAll() method.
+        return $this->dcoreApi->requestWebsocket(new GetNftCount());
     }
 
     /**
@@ -123,7 +141,7 @@ class NftApi extends BaseApi implements NftApiInterface
      */
     public function countAllData(): string
     {
-        // TODO: Implement countAllData() method.
+        return $this->dcoreApi->requestWebsocket(new GetNftDataCount());
     }
 
     /**
@@ -180,7 +198,7 @@ class NftApi extends BaseApi implements NftApiInterface
     public function createNftCreateOperation(
         string $symbol,
         NftOptions $options,
-        $model,
+        NftModel $model,
         bool $transferable,
         $fee = null
     ): NftCreateOperation {
@@ -188,7 +206,7 @@ class NftApi extends BaseApi implements NftApiInterface
         $operation
             ->setSymbol($symbol)
             ->setOptions($options)
-            ->setDefinitions($model)
+            ->setDefinitions($model->createDefinitions())
             ->setTransferable($transferable)
             ->setFee($fee);
         return $operation;
@@ -203,7 +221,7 @@ class NftApi extends BaseApi implements NftApiInterface
         string $maxSupply,
         bool $fixedMaxSupply,
         string $description,
-        $model,
+        NftModel $model,
         bool $transferable,
         $fee = null
     ): TransactionConfirmation {
@@ -280,7 +298,7 @@ class NftApi extends BaseApi implements NftApiInterface
         ChainObject $id,
         Memo $memo = null,
         Fee $fee = null
-    ): NftOperation {
+    ): NftTransferOperation {
         // TODO: Implement createTransferOperation() method.
     }
 

--- a/src/Sdk/NftApi.php
+++ b/src/Sdk/NftApi.php
@@ -5,7 +5,6 @@ namespace DCorePHP\Sdk;
 use DCorePHP\Crypto\Credentials;
 use DCorePHP\DCoreApi;
 use DCorePHP\Exception\ObjectNotFoundException;
-use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\Asset\AssetAmount;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Memo;
@@ -284,11 +283,21 @@ class NftApi extends BaseApi implements NftApiInterface
         ChainObject $issuer,
         string $idOrSymbol,
         ChainObject $to,
-        $data = null,
+        NftModel $data = null,
         Memo $memo = null,
         $fee = null
     ): NftIssueOperation {
-        // TODO: Implement createIssueOperation() method.
+        $nft = $this->get($idOrSymbol);
+        $dataArray = $data ? $data->values() : [];
+        $operation = new NftIssueOperation();
+        $operation
+            ->setIssuer($issuer)
+            ->setId($nft->getId())
+            ->setTo($to)
+            ->setData($dataArray)
+            ->setMemo($memo)
+            ->setFee($fee);
+        return $operation;
     }
 
     /**
@@ -298,11 +307,16 @@ class NftApi extends BaseApi implements NftApiInterface
         Credentials $credentials,
         string $idOrSymbol,
         ChainObject $to,
-        $data = null,
+        NftModel $data = null,
         Memo $memo = null,
-        Fee $fee = null
+        $fee = null
     ): TransactionConfirmation {
-        // TODO: Implement issue() method.
+        $fee = $fee ?: new AssetAmount();
+
+        return $this->dcoreApi->getBroadcastApi()->broadcastOperationWithECKeyPairWithCallback(
+            $credentials->getKeyPair(),
+            $this->createIssueOperation($credentials->getAccount(), $idOrSymbol, $to, $data, $memo, $fee)
+        );
     }
 
     /**

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace DCorePHP\Sdk;
+
+use DCorePHP\Crypto\Credentials;
+use DCorePHP\DCoreApi;
+use DCorePHP\Exception\InvalidApiCallException;
+use DCorePHP\Exception\ObjectNotFoundException;
+use DCorePHP\Exception\ValidationException;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\Memo;
+use DCorePHP\Model\Nft;
+use DCorePHP\Model\NftData;
+use DCorePHP\Model\NftOptions;
+use DCorePHP\Model\Operation\NftCreateOperation;
+use DCorePHP\Model\Proposal\Fee;
+use DCorePHP\Model\TransactionConfirmation;
+use Exception;
+use WebSocket\BadOpcodeException;
+
+interface NftApiInterface
+{
+    /**
+     * Get NFT by id or symbol
+     *
+     * @param string $idOrSymbol
+     *
+     * @return Nft
+     *
+     * @throws ValidationException
+     */
+    public function get(string $idOrSymbol): Nft;
+
+    /**
+     * Get NFTs by id
+     *
+     * @param ChainObject[] $ids
+     *
+     * @return array
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getAll(array $ids): array;
+
+    /**
+     * Get NFT by id
+     *
+     * @param ChainObject $id
+     * @return Nft
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     * @throws ObjectNotFoundException
+     */
+    public function getById(ChainObject $id): Nft;
+
+    /**
+     * Get NFTs by symbol
+     *
+     * @param array $symbols
+     *
+     * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getAllBySymbol(array $symbols): array;
+
+    /**
+     * Get NFT by symbol
+     *
+     * @param string $symbol
+     *
+     * @return Nft
+     *
+     * @throws ObjectNotFoundException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getBySymbol(string $symbol): Nft;
+
+    /**
+     * Get NFT data instances with parsed model
+     *
+     * @param array $ids
+     * @return array
+     */
+    public function getAllData(array $ids): array;
+
+    /**
+     * Get NFT data instances with raw model
+     *
+     * @param array $ids
+     *
+     * @return array
+     */
+    public function getAllDataRaw(array $ids): array;
+
+    /**
+     * Get NFT data instances with registered model, use [DCoreApi.registerNfts] to register nft model by object id,
+     * if the model is not registered, [RawNft] will be used
+     *
+     * @param ChainObject $id
+     *
+     * @return NftData
+     */
+    public function getData(ChainObject $id): NftData;
+
+    /**
+     * Get NFT data instance with raw model
+     *
+     * @param ChainObject $id
+     *
+     * @return NftData
+     */
+    public function getDataRaw(ChainObject $id): NftData;
+
+    /**
+     * Count all NFTs
+     *
+     * @return string
+     */
+    public function countAll(): string;
+
+    /**
+     * Count all NFT data instances
+     *
+     * @return string
+     */
+    public function countAllData(): string;
+
+    /**
+     * Get NFT balances per account with raw model
+     *
+     * @param ChainObject $account
+     * @param array $nftIds
+     *
+     * @return array NFT data instances with raw model
+     */
+    public function getNftBalancesRaw(ChainObject $account, array $nftIds = []): array;
+
+    /**
+     * Get NFT balances per account with registered model, use [DCoreApi.registerNfts] to register nft model by object id,
+     * if the model is not registered, [RawNft] will be used
+     *
+     * @param ChainObject $account
+     * @param array $nftIds
+     *
+     * @return array
+     */
+    public function getNftBalances(ChainObject $account, array $nftIds = []): array;
+
+    /**
+     * Get NFTs alphabetically by symbol name
+     *
+     * @param string $lowerBound of symbol names to retrieve
+     * @param int $limit maximum number of NFTs to fetch (must not exceed 100)
+     *
+     * @return array NFTs found
+     */
+    public function listAllRelative(string $lowerBound = '', int $limit = DCoreApi::REQ_LIMIT_MAX): array;
+
+    /**
+     * @param ChainObject $nftId
+     * @return array
+     */
+    public function listDataByNft(ChainObject $nftId): array;
+
+    /**
+     * @param ChainObject $nftId
+     * @return array
+     */
+    public function listDataByNftRaw(ChainObject $nftId): array;
+
+    /**
+     * @param ChainObject $nftDataId
+     * @return array
+     */
+    public function searchNftHistory(ChainObject $nftDataId): array;
+
+    /**
+     * @param string $symbol
+     * @param NftOptions $options
+     * @param $model
+     * @param bool $transferable
+     * @param null $fee
+     *
+     * @return NftCreateOperation
+     *
+     * @throws ValidationException
+     */
+    public function createNftCreateOperation(string $symbol, NftOptions $options, $model, bool $transferable, $fee = null): NftCreateOperation;
+
+    /**
+     * Create NFT
+     *
+     * @param Credentials $credentials
+     * @param string $symbol
+     * @param string $maxSupply
+     * @param bool $fixedMaxSupply
+     * @param string $description
+     * @param $model
+     * @param bool $transferable
+     * @param null $fee
+     *
+     * @return TransactionConfirmation
+     *
+     * @throws Exception
+     */
+    public function create(Credentials $credentials, string $symbol, string $maxSupply, bool $fixedMaxSupply, string $description, $model, bool $transferable, $fee = null): TransactionConfirmation;
+
+    /**
+     * Create NFT update operation. Fills model with actual values.
+     *
+     * @param string $idOrSymbol
+     * @param Fee|null $fee
+     *
+     * @return NftUpdateOperation
+     */
+    public function createUpdateOperation(string $idOrSymbol, Fee $fee = null): NftUpdateOperation;
+
+    /**
+     * Update NFT
+     *
+     * @param Credentials $credentials
+     * @param string $idOrSymbol
+     * @param string|null $maxSupply
+     * @param bool|null $fixedMaxSupply
+     * @param string|null $description
+     * @param Fee|null $fee
+     *
+     * @return TransactionConfirmation
+     */
+    public function update(Credentials $credentials, string $idOrSymbol, string $maxSupply = null, bool $fixedMaxSupply = null, string $description = null, Fee $fee = null): TransactionConfirmation;
+
+    /**
+     * Create NFT issue operation. Creates a NFT data instance.
+     *
+     * @param ChainObject $issuer
+     * @param string $idOrSymbol
+     * @param ChainObject $to
+     * @param null $data
+     * @param Memo|null $memo
+     * @param Fee|null $fee
+     *
+     * @return NftIssueOperation
+     */
+    public function createIssueOperation(ChainObject $issuer, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, Fee $fee = null): NftIssueOperation;
+
+    /**
+     * Issue NFT. Creates a NFT data instance.
+     *
+     * @param Credentials $credentials
+     * @param string $idOrSymbol
+     * @param ChainObject $to
+     * @param null $data
+     * @param Memo|null $memo
+     * @param Fee|null $fee
+     *
+     * @return TransactionConfirmation
+     */
+    public function issue(Credentials $credentials, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, Fee $fee = null): TransactionConfirmation;
+
+    /**
+     * Create NFT data instance transfer operation
+     *
+     * @param ChainObject $from
+     * @param ChainObject $to
+     * @param ChainObject $id
+     * @param Memo|null $memo
+     * @param Fee|null $fee
+     *
+     * @return NftOperation
+     */
+    public function createTransferOperation(ChainObject $from, ChainObject $to, ChainObject $id, Memo $memo = null, Fee $fee = null): NftOperation;
+
+    /**
+     * Transfer NFT data instance
+     *
+     * @param Credentials $credentials
+     * @param ChainObject $to
+     * @param ChainObject $from
+     * @param Memo|null $memo
+     * @param Fee|null $fee
+     *
+     * @return TransactionConfirmation
+     */
+    public function transfer(Credentials $credentials, ChainObject $to, ChainObject $from, Memo $memo = null, Fee $fee = null): TransactionConfirmation;
+
+    /**
+     * Create NFT data instance update operation
+     *
+     * @param ChainObject $modifier
+     * @param ChainObject $id
+     * @param Fee|null $fee
+     *
+     * @return NftUpdateDataOperation
+     */
+    public function createUpdateDataOperation(ChainObject $modifier, ChainObject $id, Fee $fee = null): NftUpdateDataOperation;
+
+    /**
+     * Create NFT data instance update operation
+     *
+     * @param ChainObject $modifier
+     * @param ChainObject $id
+     * @param $newData
+     * @param Fee|null $fee
+     *
+     * @return NftUpdateDataOperation
+     */
+    public function createUpdateDataOperationWithNewData(ChainObject $modifier, ChainObject $id, $newData, Fee $fee = null): NftUpdateDataOperation;
+
+    /**
+     * Update NFT data instance
+     *
+     * @param Credentials $credentials
+     * @param ChainObject $id
+     * @param array $values
+     * @param Fee|null $fee
+     *
+     * @return TransactionConfirmation
+     */
+    public function updateData(Credentials $credentials, ChainObject $id, array $values, Fee $fee = null): TransactionConfirmation;
+
+    /**
+     * Update NFT data instance
+     *
+     * @param Credentials $credentials
+     * @param ChainObject $id
+     * @param $newData
+     * @param Fee|null $fee
+     *
+     * @return TransactionConfirmation
+     */
+    public function updateDataWithNewData(Credentials $credentials, ChainObject $id, $newData, Fee $fee = null): TransactionConfirmation;
+}

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -269,13 +269,19 @@ interface NftApiInterface
      * @param ChainObject $issuer
      * @param string $idOrSymbol
      * @param ChainObject $to
-     * @param null $data
+     * @param NftModel $data
      * @param Memo|null $memo
      * @param null $fee
      *
      * @return NftIssueOperation
+     *
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     * @throws ExceptionInterface
      */
-    public function createIssueOperation(ChainObject $issuer, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, $fee = null): NftIssueOperation;
+    public function createIssueOperation(ChainObject $issuer, string $idOrSymbol, ChainObject $to, NftModel $data = null, Memo $memo = null, $fee = null): NftIssueOperation;
 
     /**
      * Issue NFT. Creates a NFT data instance.
@@ -283,13 +289,16 @@ interface NftApiInterface
      * @param Credentials $credentials
      * @param string $idOrSymbol
      * @param ChainObject $to
-     * @param null $data
+     * @param NftModel $data
      * @param Memo|null $memo
-     * @param Fee|null $fee
+     * @param $fee
      *
      * @return TransactionConfirmation
+     *
+     * @throws Exception
+     * @throws ExceptionInterface
      */
-    public function issue(Credentials $credentials, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, Fee $fee = null): TransactionConfirmation;
+    public function issue(Credentials $credentials, string $idOrSymbol, ChainObject $to, NftModel $data = null, Memo $memo = null, $fee = null): TransactionConfirmation;
 
     /**
      * Create NFT data instance transfer operation

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -236,11 +236,16 @@ interface NftApiInterface
      * Create NFT update operation. Fills model with actual values.
      *
      * @param string $idOrSymbol
-     * @param Fee|null $fee
+     * @param null $fee
      *
      * @return NftUpdateOperation
+     *
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
-    public function createUpdateOperation(string $idOrSymbol, Fee $fee = null): NftUpdateOperation;
+    public function createUpdateOperation(string $idOrSymbol, $fee = null): NftUpdateOperation;
 
     /**
      * Update NFT
@@ -250,11 +255,13 @@ interface NftApiInterface
      * @param string|null $maxSupply
      * @param bool|null $fixedMaxSupply
      * @param string|null $description
-     * @param Fee|null $fee
+     * @param null $fee
      *
      * @return TransactionConfirmation
+     *
+     * @throws Exception
      */
-    public function update(Credentials $credentials, string $idOrSymbol, string $maxSupply = null, bool $fixedMaxSupply = null, string $description = null, Fee $fee = null): TransactionConfirmation;
+    public function update(Credentials $credentials, string $idOrSymbol, string $maxSupply = null, bool $fixedMaxSupply = null, string $description = null, $fee = null): TransactionConfirmation;
 
     /**
      * Create NFT issue operation. Creates a NFT data instance.
@@ -264,11 +271,11 @@ interface NftApiInterface
      * @param ChainObject $to
      * @param null $data
      * @param Memo|null $memo
-     * @param Fee|null $fee
+     * @param null $fee
      *
      * @return NftIssueOperation
      */
-    public function createIssueOperation(ChainObject $issuer, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, Fee $fee = null): NftIssueOperation;
+    public function createIssueOperation(ChainObject $issuer, string $idOrSymbol, ChainObject $to, $data = null, Memo $memo = null, $fee = null): NftIssueOperation;
 
     /**
      * Issue NFT. Creates a NFT data instance.

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -178,6 +178,9 @@ interface NftApiInterface
      * @param int $limit maximum number of NFTs to fetch (must not exceed 100)
      *
      * @return array NFTs found
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function listAllRelative(string $lowerBound = '', int $limit = DCoreApi::REQ_LIMIT_MAX): array;
 

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -307,11 +307,13 @@ interface NftApiInterface
      * @param ChainObject $to
      * @param ChainObject $id
      * @param Memo|null $memo
-     * @param Fee|null $fee
+     * @param $fee
      *
      * @return NftTransferOperation
+     *
+     * @throws ValidationException
      */
-    public function createTransferOperation(ChainObject $from, ChainObject $to, ChainObject $id, Memo $memo = null, Fee $fee = null): NftTransferOperation;
+    public function createTransferOperation(ChainObject $from, ChainObject $to, ChainObject $id, Memo $memo = null, $fee = null): NftTransferOperation;
 
     /**
      * Transfer NFT data instance
@@ -320,11 +322,13 @@ interface NftApiInterface
      * @param ChainObject $to
      * @param ChainObject $from
      * @param Memo|null $memo
-     * @param Fee|null $fee
+     * @param $fee
      *
      * @return TransactionConfirmation
+     *
+     * @throws Exception
      */
-    public function transfer(Credentials $credentials, ChainObject $to, ChainObject $from, Memo $memo = null, Fee $fee = null): TransactionConfirmation;
+    public function transfer(Credentials $credentials, ChainObject $to, ChainObject $from, Memo $memo = null, $fee = null): TransactionConfirmation;
 
     /**
      * Create NFT data instance update operation

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -20,6 +20,7 @@ use DCorePHP\Model\Operation\NftUpdateDataOperation;
 use DCorePHP\Model\Operation\NftUpdateOperation;
 use DCorePHP\Model\Proposal\Fee;
 use DCorePHP\Model\TransactionConfirmation;
+use DCorePHP\Model\Variant;
 use Exception;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use WebSocket\BadOpcodeException;
@@ -89,10 +90,24 @@ interface NftApiInterface
     public function getBySymbol(string $symbol): Nft;
 
     /**
+     * @param array $ids
+     * @param string $class
+     *
+     * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getAllDataWithClass(array $ids, string $class): array;
+
+    /**
      * Get NFT data instances with parsed model
      *
      * @param array $ids
      * @return NftData[]
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getAllData(array $ids): array;
 
@@ -109,12 +124,30 @@ interface NftApiInterface
     public function getAllDataRaw(array $ids): array;
 
     /**
+     * Get NFT data instance with parsed model
+     *
+     * @param ChainObject $id
+     * @param string $class
+     *
+     * @return NftData
+     *
+     * @throws ObjectNotFoundException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getDataWithClass(ChainObject $id, string $class): NftData;
+
+    /**
      * Get NFT data instances with registered model, use [DCoreApi.registerNfts] to register nft model by object id,
      * if the model is not registered, [RawNft] will be used
      *
      * @param ChainObject $id
      *
      * @return NftData
+     *
+     * @throws ObjectNotFoundException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getData(ChainObject $id): NftData;
 
@@ -127,6 +160,7 @@ interface NftApiInterface
      *
      * @throws InvalidApiCallException
      * @throws BadOpcodeException
+     * @throws ObjectNotFoundException
      */
     public function getDataRaw(ChainObject $id): NftData;
 
@@ -157,6 +191,9 @@ interface NftApiInterface
      * @param array $nftIds
      *
      * @return array NFT data instances with raw model
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getNftBalancesRaw(ChainObject $account, array $nftIds = []): array;
 
@@ -168,8 +205,25 @@ interface NftApiInterface
      * @param array $nftIds
      *
      * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getNftBalances(ChainObject $account, array $nftIds = []): array;
+
+    /**
+     * Get NFT balances per account with parsed model
+     *
+     * @param ChainObject $account
+     * @param ChainObject $nftId
+     * @param string $class
+     *
+     * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function getNftBalancesWithClass(ChainObject $account, ChainObject $nftId, string $class): array;
 
     /**
      * Get NFTs alphabetically by symbol name
@@ -185,20 +239,44 @@ interface NftApiInterface
     public function listAllRelative(string $lowerBound = '', int $limit = DCoreApi::REQ_LIMIT_MAX): array;
 
     /**
+     * Get NFT data instances with parsed model
+     *
      * @param ChainObject $nftId
-     * @return array
+     * @param string $class
+     *
+     * @return NftData[]
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     */
+    public function listDataByNftWithClass(ChainObject $nftId, string $class): array;
+
+    /**
+     * @param ChainObject $nftId
+     *
+     * @return NftData[]
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function listDataByNft(ChainObject $nftId): array;
 
     /**
      * @param ChainObject $nftId
-     * @return array
+     * @return NftData[]
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function listDataByNftRaw(ChainObject $nftId): array;
 
     /**
      * @param ChainObject $nftDataId
+     *
      * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function searchNftHistory(ChainObject $nftDataId): array;
 
@@ -338,23 +416,24 @@ interface NftApiInterface
      *
      * @param ChainObject $modifier
      * @param ChainObject $id
-     * @param Fee|null $fee
+     * @param Variant[] $values
+     * @param $fee
      *
      * @return NftUpdateDataOperation
      */
-    public function createUpdateDataOperation(ChainObject $modifier, ChainObject $id, Fee $fee = null): NftUpdateDataOperation;
+    public function createUpdateDataOperationRaw(ChainObject $modifier, ChainObject $id, array $values, $fee = null): NftUpdateDataOperation;
 
     /**
      * Create NFT data instance update operation
      *
      * @param ChainObject $modifier
      * @param ChainObject $id
-     * @param $newData
-     * @param Fee|null $fee
+     * @param NftModel $newData
+     * @param $fee
      *
      * @return NftUpdateDataOperation
      */
-    public function createUpdateDataOperationWithNewData(ChainObject $modifier, ChainObject $id, $newData, Fee $fee = null): NftUpdateDataOperation;
+    public function createUpdateDataOperation(ChainObject $modifier, ChainObject $id, NftModel $newData, $fee = null): NftUpdateDataOperation;
 
     /**
      * Update NFT data instance
@@ -362,21 +441,21 @@ interface NftApiInterface
      * @param Credentials $credentials
      * @param ChainObject $id
      * @param array $values
-     * @param Fee|null $fee
+     * @param $fee
      *
      * @return TransactionConfirmation
      */
-    public function updateData(Credentials $credentials, ChainObject $id, array $values, Fee $fee = null): TransactionConfirmation;
+    public function updateDataRaw(Credentials $credentials, ChainObject $id, array $values, $fee = null): TransactionConfirmation;
 
     /**
      * Update NFT data instance
      *
      * @param Credentials $credentials
      * @param ChainObject $id
-     * @param $newData
-     * @param Fee|null $fee
+     * @param NftModel $values
+     * @param $fee
      *
      * @return TransactionConfirmation
      */
-    public function updateDataWithNewData(Credentials $credentials, ChainObject $id, $newData, Fee $fee = null): TransactionConfirmation;
+    public function updateData(Credentials $credentials, ChainObject $id, NftModel $values, $fee = null): TransactionConfirmation;
 }

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -92,7 +92,7 @@ interface NftApiInterface
      * Get NFT data instances with parsed model
      *
      * @param array $ids
-     * @return array
+     * @return NftData[]
      */
     public function getAllData(array $ids): array;
 

--- a/src/Sdk/NftApiInterface.php
+++ b/src/Sdk/NftApiInterface.php
@@ -11,11 +11,17 @@ use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Memo;
 use DCorePHP\Model\Nft;
 use DCorePHP\Model\NftData;
+use DCorePHP\Model\NftModel;
 use DCorePHP\Model\NftOptions;
 use DCorePHP\Model\Operation\NftCreateOperation;
+use DCorePHP\Model\Operation\NftIssueOperation;
+use DCorePHP\Model\Operation\NftTransferOperation;
+use DCorePHP\Model\Operation\NftUpdateDataOperation;
+use DCorePHP\Model\Operation\NftUpdateOperation;
 use DCorePHP\Model\Proposal\Fee;
 use DCorePHP\Model\TransactionConfirmation;
 use Exception;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use WebSocket\BadOpcodeException;
 
 interface NftApiInterface
@@ -28,6 +34,9 @@ interface NftApiInterface
      * @return Nft
      *
      * @throws ValidationException
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
+     * @throws ObjectNotFoundException
      */
     public function get(string $idOrSymbol): Nft;
 
@@ -93,6 +102,9 @@ interface NftApiInterface
      * @param array $ids
      *
      * @return array
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getAllDataRaw(array $ids): array;
 
@@ -112,6 +124,9 @@ interface NftApiInterface
      * @param ChainObject $id
      *
      * @return NftData
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function getDataRaw(ChainObject $id): NftData;
 
@@ -119,6 +134,9 @@ interface NftApiInterface
      * Count all NFTs
      *
      * @return string
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function countAll(): string;
 
@@ -126,6 +144,9 @@ interface NftApiInterface
      * Count all NFT data instances
      *
      * @return string
+     *
+     * @throws InvalidApiCallException
+     * @throws BadOpcodeException
      */
     public function countAllData(): string;
 
@@ -181,15 +202,16 @@ interface NftApiInterface
     /**
      * @param string $symbol
      * @param NftOptions $options
-     * @param $model
+     * @param NftModel $model
      * @param bool $transferable
      * @param null $fee
      *
      * @return NftCreateOperation
      *
      * @throws ValidationException
+     * @throws ExceptionInterface
      */
-    public function createNftCreateOperation(string $symbol, NftOptions $options, $model, bool $transferable, $fee = null): NftCreateOperation;
+    public function createNftCreateOperation(string $symbol, NftOptions $options, NftModel $model, bool $transferable, $fee = null): NftCreateOperation;
 
     /**
      * Create NFT
@@ -199,15 +221,16 @@ interface NftApiInterface
      * @param string $maxSupply
      * @param bool $fixedMaxSupply
      * @param string $description
-     * @param $model
+     * @param NftModel $model
      * @param bool $transferable
      * @param null $fee
      *
      * @return TransactionConfirmation
      *
      * @throws Exception
+     * @throws ExceptionInterface
      */
-    public function create(Credentials $credentials, string $symbol, string $maxSupply, bool $fixedMaxSupply, string $description, $model, bool $transferable, $fee = null): TransactionConfirmation;
+    public function create(Credentials $credentials, string $symbol, string $maxSupply, bool $fixedMaxSupply, string $description, NftModel $model, bool $transferable, $fee = null): TransactionConfirmation;
 
     /**
      * Create NFT update operation. Fills model with actual values.
@@ -270,9 +293,9 @@ interface NftApiInterface
      * @param Memo|null $memo
      * @param Fee|null $fee
      *
-     * @return NftOperation
+     * @return NftTransferOperation
      */
-    public function createTransferOperation(ChainObject $from, ChainObject $to, ChainObject $id, Memo $memo = null, Fee $fee = null): NftOperation;
+    public function createTransferOperation(ChainObject $from, ChainObject $to, ChainObject $id, Memo $memo = null, Fee $fee = null): NftTransferOperation;
 
     /**
      * Transfer NFT data instance

--- a/tests/DCoreSDKTest.php
+++ b/tests/DCoreSDKTest.php
@@ -17,19 +17,19 @@ abstract class DCoreSDKTest extends TestCase
     public const PUBLIC_KEY_2 = 'DCT82MTCQVa9TDFmz3ZwaLzsFAmCLoJzrtFugpF72vsbuE1CpCwKy';
 
     /** @var DCoreApi */
-    protected $sdk;
+    protected static $sdk;
 
-    protected function setUp()
+    public static function setUpBeforeClass()
     {
-        $this->sdk = new DCoreApi(
+        self::$sdk = new DCoreApi(
             'http://dcore:8090/',
             'ws://dcore:8090/',
             true
         );
     }
 
-    protected function tearDown()
+    public static function tearDownAfterClass()
     {
-        $this->sdk = null;
+        self::$sdk = null;
     }
 }

--- a/tests/Model/NftApple.php
+++ b/tests/Model/NftApple.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DCorePHPTests\Model;
+
+use DCorePHP\Model\NftDataType;
+use DCorePHP\Model\NftModel;
+
+class NftApple extends NftModel
+{
+    /** @var NftDataType */
+    private $size;
+    /** @var NftDataType */
+    private $color;
+    /** @var NftDataType */
+    private $eaten;
+
+    /**
+     * NftApple constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->size = NftDataType::withValues('integer');
+        $this->color = NftDataType::withValues('string', true, NftDataType::NOBODY, 'color');
+        $this->eaten = NftDataType::withValues('boolean', false, NftDataType::BOTH, 'eaten');
+    }
+
+    /**
+     * @return NftDataType
+     */
+    public function getSize(): ?NftDataType
+    {
+        return $this->size;
+    }
+
+    /**
+     * @param NftDataType $size
+     * @return NftApple
+     */
+    public function setSize(NftDataType $size): NftApple
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * @return NftDataType
+     */
+    public function getColor(): ?NftDataType
+    {
+        return $this->color;
+    }
+
+    /**
+     * @param NftDataType $color
+     * @return NftApple
+     */
+    public function setColor(NftDataType $color): NftApple
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    /**
+     * @return NftDataType
+     */
+    public function getEaten(): ?NftDataType
+    {
+        return $this->eaten;
+    }
+
+    /**
+     * @param NftDataType $eaten
+     * @return NftApple
+     */
+    public function setEaten(NftDataType $eaten): NftApple
+    {
+        $this->eaten = $eaten;
+
+        return $this;
+    }
+}

--- a/tests/Model/NftApple.php
+++ b/tests/Model/NftApple.php
@@ -16,13 +16,17 @@ class NftApple extends NftModel
 
     /**
      * NftApple constructor.
+     *
+     * @param null $size
+     * @param null $color
+     * @param null $eaten
      */
-    public function __construct()
+    public function __construct($size = null, $color = null, $eaten = null)
     {
         parent::__construct();
-        $this->size = NftDataType::withValues('integer');
-        $this->color = NftDataType::withValues('string', true, NftDataType::NOBODY, 'color');
-        $this->eaten = NftDataType::withValues('boolean', false, NftDataType::BOTH, 'eaten');
+        $this->size = NftDataType::withValues('integer', $size);
+        $this->color = NftDataType::withValues('string', $color,true, NftDataType::NOBODY, 'color');
+        $this->eaten = NftDataType::withValues('boolean', $eaten, false, NftDataType::BOTH, 'eaten');
     }
 
     /**

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -153,4 +153,20 @@ class NftApiTest extends DCoreSDKTest
         $this->assertEquals(100, $nft->getOptions()->getMaxSupply());
         $this->assertFalse($nft->getOptions()->isFixedMaxSupply());
     }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testUpdate(): void
+    {
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->update($credentials, $this->nftSymbol, null, null, 'an apple update');
+
+        $updatedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
+        $this->assertEquals('an apple update', $updatedNft->getOptions()->getDescription());
+    }
 }

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -9,9 +9,10 @@ use DCorePHP\Exception\ObjectNotFoundException;
 use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Nft;
-use DCorePHP\Model\NftDataType;
 use DCorePHPTests\DCoreSDKTest;
+use DCorePHPTests\Model\NftApple;
 use Exception;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use WebSocket\BadOpcodeException;
 
 class NftApiTest extends DCoreSDKTest
@@ -19,25 +20,18 @@ class NftApiTest extends DCoreSDKTest
     /** @var ChainObject */
     private $testNftId;
     /** @var string */
-    private $symbol;
-    /** @var array */
-    private $nftApple;
+    private $nftSymbol;
 
     public function setUp()
     {
         parent::setUp();
 
-        $this->symbol = 'APPLE';
-        $this->nftApple = [
-            NftDataType::withValues('integer', 'size'),
-            NftDataType::withValues('string', 'color', true),
-            NftDataType::withValues('boolean', 'eaten', false, NftDataType::BOTH),
-        ];
+        $this->nftSymbol = 'APPLE' . time() . 'T';
 
         $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->create($credentials, $this->symbol, 100, false, 'an apple', $this->nftApple, true);
+        $this->sdk->getNftApi()->create($credentials, $this->nftSymbol, 100, false, 'an apple', new NftApple(), true);
 
-        $nft = $this->sdk->getNftApi()->getBySymbol($this->symbol);
+        $nft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
         $this->testNftId = $nft->getId();
 
         sleep(5);
@@ -50,10 +44,10 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetAll(): void
     {
-        $nfts = $this->sdk->getNftApi()->getAll([new ChainObject('1.10.0'), new ChainObject('1.10.1')]);
+        $nfts = $this->sdk->getNftApi()->getAll([new ChainObject($this->testNftId)]);
         /** @var Nft $nft */
         $nft = reset($nfts);
-        $this->assertEquals('APPLE', $nft->getSymbol());
+        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
         $this->assertEquals('an apple', $nft->getOptions()->getDescription());
     }
 
@@ -65,8 +59,8 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetById(): void
     {
-        $nft = $this->sdk->getNftApi()->getById(new ChainObject('1.10.0'));
-        $this->assertEquals('APPLE', $nft->getSymbol());
+        $nft = $this->sdk->getNftApi()->getById(new ChainObject($this->testNftId));
+        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
         $this->assertEquals('an apple', $nft->getOptions()->getDescription());
     }
 
@@ -89,7 +83,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetBySymbol(): void
     {
-        $nft = $this->sdk->getNftApi()->getBySymbol('APPLE');
+        $nft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
         $this->assertEquals('an apple', $nft->getOptions()->getDescription());
     }
 
@@ -99,10 +93,10 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetAllBySymbol(): void
     {
-        $nfts = $this->sdk->getNftApi()->getAllBySymbol(['APPLE', 'APPLE.NESTED']);
+        $nfts = $this->sdk->getNftApi()->getAllBySymbol([$this->nftSymbol, 'APPLE.NESTED']);
         /** @var Nft $nft */
         $nft = reset($nfts);
-        $this->assertEquals('APPLE', $nft->getSymbol());
+        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
         $this->assertEquals('an apple', $nft->getOptions()->getDescription());
     }
 
@@ -112,23 +106,46 @@ class NftApiTest extends DCoreSDKTest
         $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
     }
 
+    public function testGetAllDataRaw(): void
+    {
+        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
+//        $this->sdk->getNftApi()->getAllDataRaw([new ChainObject('1.11.0')]);
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     */
+    public function testCountAll(): void
+    {
+        $count = $this->sdk->getNftApi()->countAll();
+        $this->assertGreaterThan(0, $count);
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     */
+    public function testCountAllData(): void
+    {
+        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
+//        $count = $this->sdk->getNftApi()->countAllData();
+//        $this->assertGreaterThan(0, $count);
+    }
+
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
      * @throws ObjectNotFoundException
      * @throws ValidationException
      * @throws Exception
+     * @throws ExceptionInterface
      */
     public function testCreate(): void
     {
-        $nftModel = [
-            NftDataType::withValues('integer', 'size'),
-            NftDataType::withValues('string', 'color', true),
-            NftDataType::withValues('boolean', 'eaten', false, NftDataType::BOTH),
-        ];
         $symbol = 'APPLE' . time() . 'T';
         $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->create($credentials, $symbol, 100, false, 'an apple', $nftModel, true);
+        $this->sdk->getNftApi()->create($credentials, $symbol, 100, false, 'an apple', new NftApple(), true);
 
         $nft = $this->sdk->getNftApi()->getBySymbol($symbol);
 

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace DCorePHPTests\Sdk;
+
+use DCorePHP\Crypto\Credentials;
+use DCorePHP\Crypto\ECKeyPair;
+use DCorePHP\Exception\InvalidApiCallException;
+use DCorePHP\Exception\ObjectNotFoundException;
+use DCorePHP\Exception\ValidationException;
+use DCorePHP\Model\ChainObject;
+use DCorePHP\Model\Nft;
+use DCorePHP\Model\NftDataType;
+use DCorePHPTests\DCoreSDKTest;
+use Exception;
+use WebSocket\BadOpcodeException;
+
+class NftApiTest extends DCoreSDKTest
+{
+    /** @var ChainObject */
+    private $testNftId;
+    /** @var string */
+    private $symbol;
+    /** @var array */
+    private $nftApple;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->symbol = 'APPLE';
+        $this->nftApple = [
+            NftDataType::withValues('integer', 'size'),
+            NftDataType::withValues('string', 'color', true),
+            NftDataType::withValues('boolean', 'eaten', false, NftDataType::BOTH),
+        ];
+
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->create($credentials, $this->symbol, 100, false, 'an apple', $this->nftApple, true);
+
+        $nft = $this->sdk->getNftApi()->getBySymbol($this->symbol);
+        $this->testNftId = $nft->getId();
+
+        sleep(5);
+    }
+
+    /**
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     * @throws BadOpcodeException
+     */
+    public function testGetAll(): void
+    {
+        $nfts = $this->sdk->getNftApi()->getAll([new ChainObject('1.10.0'), new ChainObject('1.10.1')]);
+        /** @var Nft $nft */
+        $nft = reset($nfts);
+        $this->assertEquals('APPLE', $nft->getSymbol());
+        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     * @throws ObjectNotFoundException
+     */
+    public function testGetById(): void
+    {
+        $nft = $this->sdk->getNftApi()->getById(new ChainObject('1.10.0'));
+        $this->assertEquals('APPLE', $nft->getSymbol());
+        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     * @throws ObjectNotFoundException
+     */
+    public function testGetByIdFail(): void
+    {
+        $this->expectException(ObjectNotFoundException::class);
+        $this->sdk->getNftApi()->getById(new ChainObject('1.10.100000'));
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     */
+    public function testGetBySymbol(): void
+    {
+        $nft = $this->sdk->getNftApi()->getBySymbol('APPLE');
+        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     */
+    public function testGetAllBySymbol(): void
+    {
+        $nfts = $this->sdk->getNftApi()->getAllBySymbol(['APPLE', 'APPLE.NESTED']);
+        /** @var Nft $nft */
+        $nft = reset($nfts);
+        $this->assertEquals('APPLE', $nft->getSymbol());
+        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+    }
+
+    public function testGetAllData(): void
+    {
+//        $nfts = $this->sdk->getNftApi()->getAllData([new ChainObject('1.11.0'), new ChainObject('1.11.1')]);
+        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testCreate(): void
+    {
+        $nftModel = [
+            NftDataType::withValues('integer', 'size'),
+            NftDataType::withValues('string', 'color', true),
+            NftDataType::withValues('boolean', 'eaten', false, NftDataType::BOTH),
+        ];
+        $symbol = 'APPLE' . time() . 'T';
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->create($credentials, $symbol, 100, false, 'an apple', $nftModel, true);
+
+        $nft = $this->sdk->getNftApi()->getBySymbol($symbol);
+
+        $this->assertNotNull($nft);
+        $this->assertEquals(100, $nft->getOptions()->getMaxSupply());
+        $this->assertFalse($nft->getOptions()->isFixedMaxSupply());
+    }
+}

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -14,57 +14,131 @@ use DCorePHP\Model\TransactionDetail;
 use DCorePHP\Model\Variant;
 use DCorePHPTests\DCoreSDKTest;
 use DCorePHPTests\Model\NftApple;
-use Exception;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use WebSocket\BadOpcodeException;
 
 class NftApiTest extends DCoreSDKTest
 {
     /** @var ChainObject */
-    private $testNftId;
+    private static $nftId;
     /** @var string */
-    private $nftSymbol;
+    private static $symbol;
+    /** @var string */
+    private static $nftIssuedId;
 
-    public function setUp()
+    public static function setUpBeforeClass()
     {
-        parent::setUp();
+        parent::setUpBeforeClass();
 
-        $this->nftSymbol = 'APPLE' . time() . 'T';
-
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->create($credentials, $this->nftSymbol, 100, false, 'an apple', new NftApple(), true);
-
-        $nft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-        $this->testNftId = $nft->getId();
+        self::testCreate();
+        self::testUpdate();
+        self::testIssue();
+        self::testTransfer();
+        self::testUpdateData();
+        self::testUpdateDataRaw();
 
         sleep(5);
     }
 
+    public static function testCreate(): void
+    {
+        self::$symbol = 'APPLE' . time() . 'T';
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        self::$sdk->getNftApi()->create($credentials, self::$symbol, 100, false, 'an apple', new NftApple(), true);
+
+        $nft = self::$sdk->getNftApi()->getBySymbol(self::$symbol);
+        self::$nftId = $nft->getId();
+
+        self::assertNotNull($nft);
+        self::assertEquals(100, $nft->getOptions()->getMaxSupply());
+        self::assertFalse($nft->getOptions()->isFixedMaxSupply());
+    }
+
+    public static function testUpdate(): void
+    {
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        self::$sdk->getNftApi()->update($credentials, self::$symbol, null, null, 'an apple update');
+
+        $updatedNft = self::$sdk->getNftApi()->getBySymbol(self::$symbol);
+        self::assertEquals('an apple update', $updatedNft->getOptions()->getDescription());
+    }
+
+    public static function testIssue(): void
+    {
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $apple = new NftApple(5, 'red', false);
+        $notice = self::$sdk->getNftApi()->issue($credentials, self::$symbol, new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), $apple);
+        self::$nftIssuedId = $notice->getTransaction()->getOpResults()[0][1];
+
+        $issuedNft = self::$sdk->getNftApi()->getBySymbol(self::$symbol);
+        self::assertEquals(1, $issuedNft->getCurrentSupply());
+    }
+
+    public static function testTransfer(): void
+    {
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        self::$sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject(self::$nftIssuedId));
+
+        $issuedNft = self::$sdk->getNftApi()->getBySymbol(self::$symbol);
+        self::assertEquals(1, $issuedNft->getCurrentSupply());
+    }
+
+    public static function testUpdateData(): void
+    {
+        $nftData = self::$sdk->getNftApi()->getDataWithClass(new ChainObject(self::$nftIssuedId), NftApple::class);
+        /** @var NftApple $data */
+        $data = $nftData->getData();
+        $eaten = $data->getEaten()->getValue();
+        $data->getEaten()->setValue(!$data->getEaten()->getValue());
+
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        self::$sdk->getNftApi()->updateData($credentials, $nftData->getId(), $data);
+
+        $nftDataAfter = self::$sdk->getNftApi()->getDataWithClass(new ChainObject(self::$nftIssuedId), NftApple::class);
+        /** @var NftApple $dataAfter */
+        $dataAfter = $nftDataAfter->getData();
+        self::assertEquals($eaten, !$dataAfter->getEaten()->getValue());
+    }
+
+    public static function testUpdateDataRaw(): void
+    {
+        $nftData = self::$sdk->getNftApi()->getDataWithClass(new ChainObject(self::$nftIssuedId), NftApple::class);
+        /** @var NftApple $data */
+        $data = $nftData->getData();
+        $eaten = $data->getEaten()->getValue();
+        $data = [new Variant('boolean', !$eaten, $data->getEaten()->getName())];
+
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        self::$sdk->getNftApi()->updateDataRaw($credentials, $nftData->getId(), $data);
+
+        $nftDataAfter = self::$sdk->getNftApi()->getDataWithClass(new ChainObject(self::$nftIssuedId), NftApple::class);
+        /** @var NftApple $dataAfter */
+        $dataAfter = $nftDataAfter->getData();
+        self::assertEquals($eaten, !$dataAfter->getEaten()->getValue());
+    }
+
     /**
      * @throws InvalidApiCallException
-     * @throws ValidationException
      * @throws BadOpcodeException
      */
     public function testGetAll(): void
     {
-        $nfts = $this->sdk->getNftApi()->getAll([new ChainObject($this->testNftId)]);
+        $nfts = self::$sdk->getNftApi()->getAll([self::$nftId]);
         /** @var Nft $nft */
         $nft = reset($nfts);
-        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
-        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+        $this->assertEquals(self::$symbol, $nft->getSymbol());
+        $this->assertEquals(100, $nft->getOptions()->getMaxSupply());
     }
 
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
-     * @throws ValidationException
      * @throws ObjectNotFoundException
      */
     public function testGetById(): void
     {
-        $nft = $this->sdk->getNftApi()->getById(new ChainObject($this->testNftId));
-        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
-        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+        $nft = self::$sdk->getNftApi()->getById(self::$nftId);
+        $this->assertEquals(self::$symbol, $nft->getSymbol());
+        $this->assertEquals(100, $nft->getOptions()->getMaxSupply());
     }
 
     /**
@@ -76,7 +150,7 @@ class NftApiTest extends DCoreSDKTest
     public function testGetByIdFail(): void
     {
         $this->expectException(ObjectNotFoundException::class);
-        $this->sdk->getNftApi()->getById(new ChainObject('1.10.100000'));
+        self::$sdk->getNftApi()->getById(new ChainObject('1.10.100000'));
     }
 
     /**
@@ -86,8 +160,8 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetBySymbol(): void
     {
-        $nft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+        $nft = self::$sdk->getNftApi()->getBySymbol(self::$symbol);
+        $this->assertEquals(self::$symbol, $nft->getSymbol());
     }
 
     /**
@@ -96,11 +170,10 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetAllBySymbol(): void
     {
-        $nfts = $this->sdk->getNftApi()->getAllBySymbol([$this->nftSymbol, 'APPLE.NESTED']);
+        $nfts = self::$sdk->getNftApi()->getAllBySymbol([self::$symbol, 'APPLE.NESTED']);
         /** @var Nft $nft */
         $nft = reset($nfts);
-        $this->assertEquals($this->nftSymbol, $nft->getSymbol());
-        $this->assertEquals('an apple', $nft->getOptions()->getDescription());
+        $this->assertEquals(self::$symbol, $nft->getSymbol());
     }
 
     /**
@@ -110,9 +183,8 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetAllData(): void
     {
-        // TODO: Ids ?
-        $this->sdk->registerNfts(['1.10.46' => NftApple::class, '1.10.50' => NftApple::class]);
-        $nfts = $this->sdk->getNftApi()->getAllData([new ChainObject('1.11.0'), new ChainObject('1.11.1')]);
+        self::$sdk->registerNfts([self::$nftId->getId() => NftApple::class]);
+        $nfts = self::$sdk->getNftApi()->getAllData([new ChainObject(self::$nftIssuedId)]);
         /** @var NftData $nft */
         foreach ($nfts as $nft) {
             $this->assertInstanceOf(NftApple::class, $nft->getData());
@@ -126,7 +198,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetAllDataRaw(): void
     {
-        $rawData = $this->sdk->getNftApi()->getAllDataRaw([new ChainObject('1.11.0')]);
+        $rawData = self::$sdk->getNftApi()->getAllDataRaw([new ChainObject(self::$nftIssuedId)]);
         foreach ($rawData as $data) {
             $this->assertInstanceOf(NftData::class, $data);
         }
@@ -140,7 +212,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetData(): void
     {
-        $data = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        $data = self::$sdk->getNftApi()->getDataWithClass(new ChainObject(self::$nftIssuedId), NftApple::class);
         $this->assertInstanceOf(NftApple::class, $data->getData());
     }
 
@@ -152,9 +224,8 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetDataRegistered(): void
     {
-        // TODO: Id => 46 ? should be 0
-        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
-        $data = $this->sdk->getNftApi()->getData(new ChainObject('1.11.0'));
+        self::$sdk->registerNfts([self::$nftId->getId() => NftApple::class]);
+        $data = self::$sdk->getNftApi()->getData(new ChainObject(self::$nftIssuedId));
         $this->assertInstanceOf(NftApple::class, $data->getData());
     }
 
@@ -166,7 +237,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetDataRaw(): void
     {
-        $data = $this->sdk->getNftApi()->getDataRaw(new ChainObject('1.11.0'));
+        $data = self::$sdk->getNftApi()->getDataRaw(new ChainObject(self::$nftIssuedId));
         $this->assertNotNull($data);
     }
 
@@ -176,7 +247,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testCountAll(): void
     {
-        $count = $this->sdk->getNftApi()->countAll();
+        $count = self::$sdk->getNftApi()->countAll();
         $this->assertGreaterThan(0, $count);
     }
 
@@ -186,7 +257,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testCountAllData(): void
     {
-        $count = $this->sdk->getNftApi()->countAllData();
+        $count = self::$sdk->getNftApi()->countAllData();
         $this->assertGreaterThan(0, $count);
     }
 
@@ -197,7 +268,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetNftBalancesRaw(): void
     {
-        $balances = $this->sdk->getNftApi()->getNftBalancesRaw(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1));
+        $balances = self::$sdk->getNftApi()->getNftBalancesRaw(new ChainObject(DCoreSDKTest::ACCOUNT_ID_2));
         foreach ($balances as $balance) {
             $this->assertInstanceOf(NftData::class, $balance);
         }
@@ -210,9 +281,8 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetNftBalances(): void
     {
-        // TODO: Id => 46 ? should be 0
-        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
-        $balances = $this->sdk->getNftApi()->getNftBalances(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), [new ChainObject('1.10.46')]);
+        self::$sdk->registerNfts([self::$nftId->getId() => NftApple::class]);
+        $balances = self::$sdk->getNftApi()->getNftBalances(new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), [self::$nftId]);
         /** @var NftData $balance */
         $balance = reset($balances);
         $this->assertInstanceOf(NftApple::class, $balance->getData());
@@ -225,8 +295,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testGetNftBalancesWithClass(): void
     {
-        // TODO: Id => 46 ? should be 0
-        $balances = $this->sdk->getNftApi()->getNftBalancesWithClass(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), new ChainObject('1.10.46'), NftApple::class);
+        $balances = self::$sdk->getNftApi()->getNftBalancesWithClass(new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), self::$nftId, NftApple::class);
         /** @var NftData $balance */
         $balance = reset($balances);
         $this->assertInstanceOf(NftApple::class, $balance->getData());
@@ -238,7 +307,7 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testListAllRelative(): void
     {
-        $nfts = $this->sdk->getNftApi()->listAllRelative();
+        $nfts = self::$sdk->getNftApi()->listAllRelative();
 
         $this->assertGreaterThan(0, count($nfts));
 
@@ -250,12 +319,10 @@ class NftApiTest extends DCoreSDKTest
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
-     * @throws ValidationException
      */
     public function testListDataByNftRaw(): void
     {
-        // TODO: Id => 46 ? should be 0
-        $nfts = $this->sdk->getNftApi()->listDataByNftRaw(new ChainObject('1.10.46'));
+        $nfts = self::$sdk->getNftApi()->listDataByNftRaw(self::$nftId);
         foreach ($nfts as $nft) {
             $this->assertInstanceOf(NftData::class, $nft);
         }
@@ -264,13 +331,11 @@ class NftApiTest extends DCoreSDKTest
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
-     * @throws ValidationException
      */
     public function testListDataByNft(): void
     {
-        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
-        // TODO: Id => 46 ? should be 0
-        $nfts = $this->sdk->getNftApi()->listDataByNft(new ChainObject('1.10.46'));
+        self::$sdk->registerNfts([self::$nftId->getId() => NftApple::class]);
+        $nfts = self::$sdk->getNftApi()->listDataByNft(self::$nftId);
         /** @var NftData $nft */
         foreach ($nfts as $nft) {
             $this->assertInstanceOf(NftApple::class, $nft->getData());
@@ -280,12 +345,10 @@ class NftApiTest extends DCoreSDKTest
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
-     * @throws ValidationException
      */
     public function testListDataByNftWIthClass(): void
     {
-        // TODO: Id => 46 ? should be 0
-        $nfts = $this->sdk->getNftApi()->listDataByNftWithClass(new ChainObject('1.10.46'), NftApple::class);
+        $nfts = self::$sdk->getNftApi()->listDataByNftWithClass(self::$nftId, NftApple::class);
         /** @var NftData $nft */
         foreach ($nfts as $nft) {
             $this->assertInstanceOf(NftApple::class, $nft->getData());
@@ -299,132 +362,11 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testSearchNftHistory(): void
     {
-        $history = $this->sdk->getNftApi()->searchNftHistory(new ChainObject('1.11.2'));
+        $history = self::$sdk->getNftApi()->searchNftHistory(new ChainObject(self::$nftIssuedId));
         /** @var TransactionDetail $item */
         foreach ($history as $item) {
             $this->assertInstanceOf(TransactionDetail::class, $item);
-            $this->assertEquals('1.11.2', $item->getNftDataId()->getId());
+            $this->assertEquals(self::$nftIssuedId, $item->getNftDataId()->getId());
         }
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     * @throws ExceptionInterface
-     */
-    public function testCreate(): void
-    {
-        $symbol = 'APPLE' . time() . 'T';
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->create($credentials, $symbol, 100, false, 'an apple', new NftApple(), true);
-
-        $nft = $this->sdk->getNftApi()->getBySymbol($symbol);
-
-        $this->assertNotNull($nft);
-        $this->assertEquals(100, $nft->getOptions()->getMaxSupply());
-        $this->assertFalse($nft->getOptions()->isFixedMaxSupply());
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    public function testUpdate(): void
-    {
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->update($credentials, $this->nftSymbol, null, null, 'an apple update');
-
-        $updatedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-        $this->assertEquals('an apple update', $updatedNft->getOptions()->getDescription());
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws ExceptionInterface
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    public function testIssue(): void
-    {
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $apple = new NftApple(5, 'red', false);
-        $this->sdk->getNftApi()->issue($credentials, $this->nftSymbol, new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), $apple);
-
-        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-        $this->assertEquals(1, $issuedNft->getCurrentSupply());
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    public function testTransfer(): void
-    {
-//        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject('1.11.0'));
-
-        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-        dump($issuedNft);
-        $this->assertEquals(1, $issuedNft->getCurrentSupply());
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    public function testUpdateData(): void
-    {
-        $nftData = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
-        /** @var NftApple $data */
-        $data = $nftData->getData();
-        $eaten = $data->getEaten()->getValue();
-        $data->getEaten()->setValue(!$data->getEaten()->getValue());
-
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->updateData($credentials, $nftData->getId(), $data);
-
-        $nftDataAfter = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
-        /** @var NftApple $dataAfter */
-        $dataAfter = $nftDataAfter->getData();
-        $this->assertEquals($eaten, !$dataAfter->getEaten()->getValue());
-    }
-
-    /**
-     * @throws BadOpcodeException
-     * @throws InvalidApiCallException
-     * @throws ObjectNotFoundException
-     * @throws ValidationException
-     * @throws Exception
-     */
-    public function testUpdateDataRaw(): void
-    {
-        $nftData = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
-        /** @var NftApple $data */
-        $data = $nftData->getData();
-        $eaten = $data->getEaten()->getValue();
-        $data = [new Variant('boolean', !$eaten, $data->getEaten()->getName())];
-
-        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-        $this->sdk->getNftApi()->updateDataRaw($credentials, $nftData->getId(), $data);
-
-        $nftDataAfter = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
-        /** @var NftApple $dataAfter */
-        $dataAfter = $nftDataAfter->getData();
-        $this->assertEquals($eaten, !$dataAfter->getEaten()->getValue());
     }
 }

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -169,4 +169,14 @@ class NftApiTest extends DCoreSDKTest
         $updatedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
         $this->assertEquals('an apple update', $updatedNft->getOptions()->getDescription());
     }
+
+    public function testIssue(): void
+    {
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $apple = new NftApple(5, 'red', false);
+        $this->sdk->getNftApi()->issue($credentials, $this->nftSymbol, new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), $apple);
+
+        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
+        $this->assertEquals(1, $issuedNft->getCurrentSupply());
+    }
 }

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -9,6 +9,7 @@ use DCorePHP\Exception\ObjectNotFoundException;
 use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Nft;
+use DCorePHP\Model\NftData;
 use DCorePHPTests\DCoreSDKTest;
 use DCorePHPTests\Model\NftApple;
 use Exception;
@@ -102,14 +103,26 @@ class NftApiTest extends DCoreSDKTest
 
     public function testGetAllData(): void
     {
-//        $nfts = $this->sdk->getNftApi()->getAllData([new ChainObject('1.11.0'), new ChainObject('1.11.1')]);
-        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
+        // TODO: Ids ?
+        $this->sdk->registerNfts(['1.10.46' => NftApple::class, '1.10.50' => NftApple::class]);
+        $nfts = $this->sdk->getNftApi()->getAllData([new ChainObject('1.11.0'), new ChainObject('1.11.1')]);
+        /** @var NftData $nft */
+        foreach ($nfts as $nft) {
+            $this->assertInstanceOf(NftApple::class, $nft->getData());
+        }
     }
 
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
     public function testGetAllDataRaw(): void
     {
-        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
-//        $this->sdk->getNftApi()->getAllDataRaw([new ChainObject('1.11.0')]);
+        $rawData = $this->sdk->getNftApi()->getAllDataRaw([new ChainObject('1.11.0')]);
+        foreach ($rawData as $data) {
+            $this->assertInstanceOf(NftData::class, $data);
+        }
     }
 
     /**

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -136,6 +136,21 @@ class NftApiTest extends DCoreSDKTest
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
+     */
+    public function testListAllRelative(): void
+    {
+        $nfts = $this->sdk->getNftApi()->listAllRelative();
+
+        $this->assertGreaterThan(0, count($nfts));
+
+        foreach ($nfts as $nft) {
+            $this->assertInstanceOf(Nft::class, $nft);
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
      * @throws ObjectNotFoundException
      * @throws ValidationException
      * @throws Exception
@@ -189,12 +204,10 @@ class NftApiTest extends DCoreSDKTest
 
     public function testTransfer(): void
     {
-        dump($this->testNftId);
+        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
 //        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
 //        $this->sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject('1.11.2'));
 
-        dump($this->sdk->getNftApi()->countAll());
-        dump($this->sdk->getNftApi()->countAllData());
 //        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
 //        $this->assertEquals(1, $issuedNft->getCurrentSupply());
     }

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -10,6 +10,8 @@ use DCorePHP\Exception\ValidationException;
 use DCorePHP\Model\ChainObject;
 use DCorePHP\Model\Nft;
 use DCorePHP\Model\NftData;
+use DCorePHP\Model\TransactionDetail;
+use DCorePHP\Model\Variant;
 use DCorePHPTests\DCoreSDKTest;
 use DCorePHPTests\Model\NftApple;
 use Exception;
@@ -101,6 +103,11 @@ class NftApiTest extends DCoreSDKTest
         $this->assertEquals('an apple', $nft->getOptions()->getDescription());
     }
 
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
     public function testGetAllData(): void
     {
         // TODO: Ids ?
@@ -128,6 +135,44 @@ class NftApiTest extends DCoreSDKTest
     /**
      * @throws BadOpcodeException
      * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     */
+    public function testGetData(): void
+    {
+        $data = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        $this->assertInstanceOf(NftApple::class, $data->getData());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     */
+    public function testGetDataRegistered(): void
+    {
+        // TODO: Id => 46 ? should be 0
+        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
+        $data = $this->sdk->getNftApi()->getData(new ChainObject('1.11.0'));
+        $this->assertInstanceOf(NftApple::class, $data->getData());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     */
+    public function testGetDataRaw(): void
+    {
+        $data = $this->sdk->getNftApi()->getDataRaw(new ChainObject('1.11.0'));
+        $this->assertNotNull($data);
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
      */
     public function testCountAll(): void
     {
@@ -141,9 +186,50 @@ class NftApiTest extends DCoreSDKTest
      */
     public function testCountAllData(): void
     {
-        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
-//        $count = $this->sdk->getNftApi()->countAllData();
-//        $this->assertGreaterThan(0, $count);
+        $count = $this->sdk->getNftApi()->countAllData();
+        $this->assertGreaterThan(0, $count);
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testGetNftBalancesRaw(): void
+    {
+        $balances = $this->sdk->getNftApi()->getNftBalancesRaw(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1));
+        foreach ($balances as $balance) {
+            $this->assertInstanceOf(NftData::class, $balance);
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testGetNftBalances(): void
+    {
+        // TODO: Id => 46 ? should be 0
+        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
+        $balances = $this->sdk->getNftApi()->getNftBalances(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), [new ChainObject('1.10.46')]);
+        /** @var NftData $balance */
+        $balance = reset($balances);
+        $this->assertInstanceOf(NftApple::class, $balance->getData());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testGetNftBalancesWithClass(): void
+    {
+        // TODO: Id => 46 ? should be 0
+        $balances = $this->sdk->getNftApi()->getNftBalancesWithClass(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), new ChainObject('1.10.46'), NftApple::class);
+        /** @var NftData $balance */
+        $balance = reset($balances);
+        $this->assertInstanceOf(NftApple::class, $balance->getData());
     }
 
     /**
@@ -158,6 +244,66 @@ class NftApiTest extends DCoreSDKTest
 
         foreach ($nfts as $nft) {
             $this->assertInstanceOf(Nft::class, $nft);
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testListDataByNftRaw(): void
+    {
+        // TODO: Id => 46 ? should be 0
+        $nfts = $this->sdk->getNftApi()->listDataByNftRaw(new ChainObject('1.10.46'));
+        foreach ($nfts as $nft) {
+            $this->assertInstanceOf(NftData::class, $nft);
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testListDataByNft(): void
+    {
+        $this->sdk->registerNfts(['1.10.46' => NftApple::class]);
+        // TODO: Id => 46 ? should be 0
+        $nfts = $this->sdk->getNftApi()->listDataByNft(new ChainObject('1.10.46'));
+        /** @var NftData $nft */
+        foreach ($nfts as $nft) {
+            $this->assertInstanceOf(NftApple::class, $nft->getData());
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testListDataByNftWIthClass(): void
+    {
+        // TODO: Id => 46 ? should be 0
+        $nfts = $this->sdk->getNftApi()->listDataByNftWithClass(new ChainObject('1.10.46'), NftApple::class);
+        /** @var NftData $nft */
+        foreach ($nfts as $nft) {
+            $this->assertInstanceOf(NftApple::class, $nft->getData());
+        }
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ValidationException
+     */
+    public function testSearchNftHistory(): void
+    {
+        $history = $this->sdk->getNftApi()->searchNftHistory(new ChainObject('1.11.2'));
+        /** @var TransactionDetail $item */
+        foreach ($history as $item) {
+            $this->assertInstanceOf(TransactionDetail::class, $item);
+            $this->assertEquals('1.11.2', $item->getNftDataId()->getId());
         }
     }
 
@@ -204,6 +350,7 @@ class NftApiTest extends DCoreSDKTest
      * @throws InvalidApiCallException
      * @throws ObjectNotFoundException
      * @throws ValidationException
+     * @throws Exception
      */
     public function testIssue(): void
     {
@@ -215,13 +362,69 @@ class NftApiTest extends DCoreSDKTest
         $this->assertEquals(1, $issuedNft->getCurrentSupply());
     }
 
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws Exception
+     */
     public function testTransfer(): void
     {
-        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
-//        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
-//        $this->sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject('1.11.2'));
+//        $this->markTestIncomplete('This test has not been implemented yet.'); // @todo
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject('1.11.0'));
 
-//        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
-//        $this->assertEquals(1, $issuedNft->getCurrentSupply());
+        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
+        dump($issuedNft);
+        $this->assertEquals(1, $issuedNft->getCurrentSupply());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testUpdateData(): void
+    {
+        $nftData = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        /** @var NftApple $data */
+        $data = $nftData->getData();
+        $eaten = $data->getEaten()->getValue();
+        $data->getEaten()->setValue(!$data->getEaten()->getValue());
+
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->updateData($credentials, $nftData->getId(), $data);
+
+        $nftDataAfter = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        /** @var NftApple $dataAfter */
+        $dataAfter = $nftDataAfter->getData();
+        $this->assertEquals($eaten, !$dataAfter->getEaten()->getValue());
+    }
+
+    /**
+     * @throws BadOpcodeException
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     * @throws Exception
+     */
+    public function testUpdateDataRaw(): void
+    {
+        $nftData = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        /** @var NftApple $data */
+        $data = $nftData->getData();
+        $eaten = $data->getEaten()->getValue();
+        $data = [new Variant('boolean', !$eaten, $data->getEaten()->getName())];
+
+        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+        $this->sdk->getNftApi()->updateDataRaw($credentials, $nftData->getId(), $data);
+
+        $nftDataAfter = $this->sdk->getNftApi()->getDataWithClass(new ChainObject('1.11.0'), NftApple::class);
+        /** @var NftApple $dataAfter */
+        $dataAfter = $nftDataAfter->getData();
+        $this->assertEquals($eaten, !$dataAfter->getEaten()->getValue());
     }
 }

--- a/tests/Sdk/NftApiTest.php
+++ b/tests/Sdk/NftApiTest.php
@@ -170,6 +170,13 @@ class NftApiTest extends DCoreSDKTest
         $this->assertEquals('an apple update', $updatedNft->getOptions()->getDescription());
     }
 
+    /**
+     * @throws BadOpcodeException
+     * @throws ExceptionInterface
+     * @throws InvalidApiCallException
+     * @throws ObjectNotFoundException
+     * @throws ValidationException
+     */
     public function testIssue(): void
     {
         $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
@@ -178,5 +185,17 @@ class NftApiTest extends DCoreSDKTest
 
         $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
         $this->assertEquals(1, $issuedNft->getCurrentSupply());
+    }
+
+    public function testTransfer(): void
+    {
+        dump($this->testNftId);
+//        $credentials = new Credentials(new ChainObject(DCoreSDKTest::ACCOUNT_ID_1), ECKeyPair::fromBase58(DCoreSDKTest::PRIVATE_KEY_1));
+//        $this->sdk->getNftApi()->transfer($credentials, new ChainObject(DCoreSDKTest::ACCOUNT_ID_2), new ChainObject('1.11.2'));
+
+        dump($this->sdk->getNftApi()->countAll());
+        dump($this->sdk->getNftApi()->countAllData());
+//        $issuedNft = $this->sdk->getNftApi()->getBySymbol($this->nftSymbol);
+//        $this->assertEquals(1, $issuedNft->getCurrentSupply());
     }
 }


### PR DESCRIPTION
As PHP isn't as flexible language as is Kotlin and Typescript, NFT Api methods come with their limitations.
Differences with other SDKs:

- As PHP has a hard time with big numbers, we use strings for those, unfortunately because of this we have to strip quotes from json request to make it seem as a number when marked as `integer` in `NFTModel`
- No annotations, therefore example model `NftApple` looks like [this](https://github.com/DECENTfoundation/DCorePHP-SDK/blob/e88a6a843b8d88e46c27cc4636faa45f8c029023/tests/Model/NftApple.php). User has to implicitly specify more data about the model than in other SDKs.
- Raw updates also have to specify more data with help of additional `Variant` model, can be seen [here](https://github.com/DECENTfoundation/DCorePHP-SDK/blob/e88a6a843b8d88e46c27cc4636faa45f8c029023/tests/Sdk/NftApiTest.php#L102)
- More differences can be found in file [NftApiTest](https://github.com/DECENTfoundation/DCorePHP-SDK/blob/e88a6a843b8d88e46c27cc4636faa45f8c029023/tests/Sdk/NftApiTest.php)

_There is a possibility of annotations and therefore simplifying user's workflow via library `doctrine/annotations`. However this comes with a portion of danger as described in draft PR #39._